### PR TITLE
chore(flake/spicetify-nix): `2e3b9ea2` -> `12c5bf55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -780,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724645793,
-        "narHash": "sha256-z0QdJ8N24msqy6uakRNHpCsrNsswTA9/Evsd3+DOAZc=",
+        "lastModified": 1724732223,
+        "narHash": "sha256-W+/vVPdDSf10R7YO1jI8V0HFKWKYnqtKfP+d7nw57p0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "2e3b9ea2f89113d71ab57127ca7226253afd2660",
+        "rev": "12c5bf55a7f5d1466b91a0f8275f0aa2b5b214cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`12c5bf55`](https://github.com/Gerg-L/spicetify-nix/commit/12c5bf55a7f5d1466b91a0f8275f0aa2b5b214cc) | `` CI update 2024-08-27 `` |