### PR TITLE
chore(flake/nixpkgs-stable): `797f7dc4` -> `2527da1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -597,11 +597,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724316499,
-        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "lastModified": 1724531977,
+        "narHash": "sha256-XROVLf9ti4rrNCFLr+DmXRZtPjCQTW4cYy59owTEmxk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "rev": "2527da1ef492c495d5391f3bcf9c1dd9f4514e32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`49a67953`](https://github.com/NixOS/nixpkgs/commit/49a67953e47d846cb8f6566611cd3eaeff5e9c9c) | `` librewolf-unwrapped: 129.0.1 -> 129.0.1-1 ``                                               |
| [`a96391a3`](https://github.com/NixOS/nixpkgs/commit/a96391a3faea2b68423cf7988a091ddd62ff87ef) | `` librewolf-unwrapped: use nvidia wayland vendored patches, format using nixfmt-rfc-style `` |
| [`b60e13a1`](https://github.com/NixOS/nixpkgs/commit/b60e13a1d5b33b7d1c492ac443e51575337cebc8) | `` signal-desktop: 7.19.0 -> 7.21.0 ``                                                        |
| [`3d512e18`](https://github.com/NixOS/nixpkgs/commit/3d512e1832b1bce1006ada313596f2352472af1f) | `` fastly: 10.13.1 -> 10.13.3 ``                                                              |
| [`53d5d2be`](https://github.com/NixOS/nixpkgs/commit/53d5d2be6da58a50807997f42ececd8145358513) | `` nixos/ups: restart upsdrv.service on config changes ``                                     |
| [`1ace5f2e`](https://github.com/NixOS/nixpkgs/commit/1ace5f2e7aa2f1d2ceaf8bb4e00f58f9cf28c895) | `` ungoogled-chromium: 127.0.6533.119-2 -> 128.0.6613.84-1 ``                                 |
| [`3fda748f`](https://github.com/NixOS/nixpkgs/commit/3fda748f5470c408234629d94dd53e622ad7d838) | `` chromium,chromedriver: 127.0.6533.119 -> 128.0.6613.84 ``                                  |
| [`d10675c4`](https://github.com/NixOS/nixpkgs/commit/d10675c43128b3d0d18f231828aa941c2ac34c3b) | `` nextcloudPackages: update ``                                                               |
| [`a011d863`](https://github.com/NixOS/nixpkgs/commit/a011d8634e76c61808a10920bf48b291fe783a0f) | `` nextcloud29: 29.0.4 -> 29.0.5 ``                                                           |
| [`9465c61b`](https://github.com/NixOS/nixpkgs/commit/9465c61bb2ebc53841389cb5f413968773ab1c63) | `` nextcloud28: 28.0.8 -> 28.0.9 ``                                                           |
| [`0f74c87e`](https://github.com/NixOS/nixpkgs/commit/0f74c87e84d640e26bdb15454ca210e3147c9f98) | `` meshcentral: 1.1.26 -> 1.1.27 ``                                                           |
| [`3e945553`](https://github.com/NixOS/nixpkgs/commit/3e9455537d4ef02b13b2380ea73426a9efedfd94) | `` nix-perl: fix build for 2.24 ``                                                            |
| [`59bc7ee1`](https://github.com/NixOS/nixpkgs/commit/59bc7ee12b70acaa9bd5aa3be31d8dce2b53e9bc) | `` google-chrome: 127.0.6533.119 -> 128.0.6613.84/128.0.6613.85 ``                            |
| [`aaaf6cc6`](https://github.com/NixOS/nixpkgs/commit/aaaf6cc690d70d75fde12dc5960f2059fabfd20b) | `` nut: enable the GPIO driver ``                                                             |
| [`5b3f2818`](https://github.com/NixOS/nixpkgs/commit/5b3f28182729fd79c9365e84a1576a582259b039) | `` nut: 2.8.0 -> 2.8.2 ``                                                                     |
| [`96c742c7`](https://github.com/NixOS/nixpkgs/commit/96c742c78f5a2a47d72252eeb5634a093e7c2ab8) | `` kanidm: lower rust requrement to 1.77 ``                                                   |
| [`00abdbc6`](https://github.com/NixOS/nixpkgs/commit/00abdbc62033e9717a69f453e18ece8ee8b83d3a) | `` nixos/tests/kanidm: bind certs path to fix ofborg tests ``                                 |
| [`f10dac3c`](https://github.com/NixOS/nixpkgs/commit/f10dac3c89a311343f41b42c917e562e382e68fc) | `` kanidm: 1.3.2 -> 1.3.3 ``                                                                  |
| [`33afc30f`](https://github.com/NixOS/nixpkgs/commit/33afc30f272133683f5211a3c5910d0a304ad24f) | `` kanidm: pin updatescript to version tags ``                                                |
| [`70694011`](https://github.com/NixOS/nixpkgs/commit/706940115d5312516b8ef24772f136e3c7d70ea1) | `` kanidm: 1.3.1 -> 1.3.2 ``                                                                  |
| [`13b70069`](https://github.com/NixOS/nixpkgs/commit/13b70069b757b5da7e3fb48e20e9095e8fa8bb26) | `` kanidm: 1.2.3 -> 1.3.1 ``                                                                  |
| [`213edbbc`](https://github.com/NixOS/nixpkgs/commit/213edbbcfed0ec4dd671736c044e92e7dee82ac5) | `` [nixos-24.05] zed-editor: remove package ``                                                |
| [`583b0b0c`](https://github.com/NixOS/nixpkgs/commit/583b0b0c1c5563a58166c43bf26f683e324bfa09) | `` floorp: align build options with upstream ``                                               |
| [`04830225`](https://github.com/NixOS/nixpkgs/commit/0483022561b5bd3235a791626c34ae1616cebe03) | `` floorp: 11.16.0 -> 11.17.5 ``                                                              |
| [`e2e2a9e3`](https://github.com/NixOS/nixpkgs/commit/e2e2a9e3adea2c288a169f6ffc01f61acc044558) | `` skypeforlinux: adopt ``                                                                    |
| [`2219b8ff`](https://github.com/NixOS/nixpkgs/commit/2219b8ffd1eea272441eb755507729682fb240f6) | `` skypeforlinux: 8.119.0.201 -> 8.126.0.208 ``                                               |
| [`930a46ff`](https://github.com/NixOS/nixpkgs/commit/930a46ff02da6fcc6e015f31e0f2971214b308dc) | `` mealie: fix relative path in code handling backup ``                                       |
| [`2a02822b`](https://github.com/NixOS/nixpkgs/commit/2a02822b466ffb9f1c02d07c5dd6b96d08b56c6b) | `` gitlab-container-registry: 4.6.0 -> 4.7.0 ``                                               |
| [`30e2ce37`](https://github.com/NixOS/nixpkgs/commit/30e2ce37efa6123ac6ce1190359517547e7c9ed0) | `` gitlab: 17.2.1 -> 17.2.2 ``                                                                |
| [`805cb4dc`](https://github.com/NixOS/nixpkgs/commit/805cb4dce7d36db8c0c7001f4943b65b2ee8b7b8) | `` gitlab: 17.2.0 -> 17.2.1 ``                                                                |
| [`f7416676`](https://github.com/NixOS/nixpkgs/commit/f7416676e02ce77fb6e1c6835550fedd787d5cab) | `` linux-wallpaperengine: drop ``                                                             |
| [`fa7d5c83`](https://github.com/NixOS/nixpkgs/commit/fa7d5c83809e1ba4487399402847178cd1a976d4) | `` raycast: 1.81.0 -> 1.81.2 ``                                                               |
| [`0499e8ca`](https://github.com/NixOS/nixpkgs/commit/0499e8ca36942085449ed4b03775fa0fc871ff1a) | `` raycast: 1.80.0 -> 1.81.0 ``                                                               |
| [`dbbc0333`](https://github.com/NixOS/nixpkgs/commit/dbbc033384d08b040c0d16d3a90521b9acea3561) | `` viceroy: 0.10.2 -> 0.11.0 ``                                                               |
| [`4be97a3b`](https://github.com/NixOS/nixpkgs/commit/4be97a3bc6d6444e0eaeb0a46081994168495c4e) | `` floorp: 11.15.0 -> 11.16.0 ``                                                              |
| [`40b84fb8`](https://github.com/NixOS/nixpkgs/commit/40b84fb84aa0f1b5cd59a33be2ab7bf4a143c125) | `` floorp: fix substitution of executable ``                                                  |
| [`9eb6d1d0`](https://github.com/NixOS/nixpkgs/commit/9eb6d1d0bde1c17ba2f796c187fbd402baf00e80) | `` floorp: 11.14.1 -> 11.15.0 ``                                                              |
| [`97b8c922`](https://github.com/NixOS/nixpkgs/commit/97b8c92290871a0d7d85fb89639384e54f996efc) | `` floorp: patch .desktop PWA file command path ``                                            |
| [`011a56ef`](https://github.com/NixOS/nixpkgs/commit/011a56ef3b3339b7e12300cc89f859e83dff7de1) | `` floorp: 11.3.3 -> 11.14.1 ``                                                               |
| [`9c964dc0`](https://github.com/NixOS/nixpkgs/commit/9c964dc07e8ec49604fcbde98e25ec029286fea9) | `` floorp-unwrapped: 11.13.2 -> 11.13.3 ``                                                    |
| [`161aae37`](https://github.com/NixOS/nixpkgs/commit/161aae37e9788551a020cc8e74221230b0ad5978) | `` bitwarden-desktop: 2024.6.0 -> 2024.6.4 ``                                                 |
| [`1f08d906`](https://github.com/NixOS/nixpkgs/commit/1f08d90683dca55468747604cd3e853b296f8eae) | `` bitwarden-desktop: 2024.5.0 -> 2024.6.0 ``                                                 |
| [`f680ce2f`](https://github.com/NixOS/nixpkgs/commit/f680ce2f23b3ca0f50ee27c990cb7b0c54312ba6) | `` bitwarden-desktop: enforce using correct Node version ``                                   |
| [`955c30c5`](https://github.com/NixOS/nixpkgs/commit/955c30c585b543aeb0113ac2270a0278f940821d) | `` bitwarden-desktop: minor cleanup ``                                                        |
| [`607c09ee`](https://github.com/NixOS/nixpkgs/commit/607c09ee3db2fc9826e2e4946c34f06f70eb7387) | `` bitwarden-desktop: 2024.4.1 -> 2024.5.0 ``                                                 |
| [`dcde996c`](https://github.com/NixOS/nixpkgs/commit/dcde996c27bf35f3a3d84e1b640327f9e988c0ac) | `` linux-rt_6_1: 6.1.102-rt37 -> 6.1.105-rt38 ``                                              |
| [`153bd0dc`](https://github.com/NixOS/nixpkgs/commit/153bd0dcf13a7ebbd6cd258367472f0f8e4d426d) | `` linux_4_19: 4.19.319 -> 4.19.320 ``                                                        |
| [`0b0cd3b1`](https://github.com/NixOS/nixpkgs/commit/0b0cd3b109db2857f939fd05d2bafa3ff9dd7de0) | `` linux_5_4: 5.4.281 -> 5.4.282 ``                                                           |
| [`8109e111`](https://github.com/NixOS/nixpkgs/commit/8109e111f4b7427bbfac509b1e1884818e73a2f0) | `` linux_5_10: 5.10.223 -> 5.10.224 ``                                                        |
| [`34113e16`](https://github.com/NixOS/nixpkgs/commit/34113e1682913a2e320293ab07be0ec6bf1d7fd3) | `` linux_5_15: 5.15.164 -> 5.15.165 ``                                                        |
| [`4a5fe8a0`](https://github.com/NixOS/nixpkgs/commit/4a5fe8a06be3114536faf7b6290843d683c447ca) | `` linux_6_1: 6.1.105 -> 6.1.106 ``                                                           |
| [`0a28ab93`](https://github.com/NixOS/nixpkgs/commit/0a28ab939e5dec47cd3dacc504a8699dd7ab1f02) | `` linux_6_6: 6.6.46 -> 6.6.47 ``                                                             |
| [`e65e6c42`](https://github.com/NixOS/nixpkgs/commit/e65e6c42187144e9904fb401f5b76d1a39f108b7) | `` linux_6_10: 6.10.5 -> 6.10.6 ``                                                            |
| [`c72cf40a`](https://github.com/NixOS/nixpkgs/commit/c72cf40af65229fed156c645a541f272e9677cd5) | `` linux_testing: 6.11-rc3 -> 6.11-rc4 ``                                                     |
| [`979e2f6b`](https://github.com/NixOS/nixpkgs/commit/979e2f6b063de76f68894071991660260c440848) | `` nginxMainline: 1.27.0 -> 1.27.1 ``                                                         |
| [`b5cefb00`](https://github.com/NixOS/nixpkgs/commit/b5cefb00d8db1e87936e80ef21e468aa6f750a62) | `` nginx: 1.26.1 -> 1.26.2 ``                                                                 |
| [`bb3971cc`](https://github.com/NixOS/nixpkgs/commit/bb3971cc2df0925a70a05303b17a1c875554e48e) | `` rcu: Properly keep src alive ``                                                            |