### PR TITLE
chore(flake/spicetify-nix): `12c5bf55` -> `c8050c21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -780,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724732223,
-        "narHash": "sha256-W+/vVPdDSf10R7YO1jI8V0HFKWKYnqtKfP+d7nw57p0=",
+        "lastModified": 1724818600,
+        "narHash": "sha256-7i8zqLTds2bXs6n/2ucSJdmKTzhajCktQ2WWFOVW3x0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "12c5bf55a7f5d1466b91a0f8275f0aa2b5b214cc",
+        "rev": "c8050c21e2e61efe0ac2d423eac9062c62bb6633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`c8050c21`](https://github.com/Gerg-L/spicetify-nix/commit/c8050c21e2e61efe0ac2d423eac9062c62bb6633) | `` CI update 2024-08-28 `` |