### PR TITLE
chore(flake/zen-browser): `b3f060f1` -> `e1313b2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1724832737,
-        "narHash": "sha256-TpaYbL7HJjpVb2tY2UqnLdkmGI73KhrfR5gCfGGIzhc=",
+        "lastModified": 1724856811,
+        "narHash": "sha256-M5aWax0KbB8moT3KpnHewN0c3brVUoz5CLK12O668bo=",
         "owner": "MarceColl",
         "repo": "zen-browser-flake",
-        "rev": "b3f060f132c209c1d486543e5cec51b710924f50",
+        "rev": "e1313b2db7d3cd6c21d3dd2ecf8e5a0b5eebacde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`e1313b2d`](https://github.com/MarceColl/zen-browser-flake/commit/e1313b2db7d3cd6c21d3dd2ecf8e5a0b5eebacde) | `` add note on 1Password integration to README (#19) `` |