### PR TITLE
chore(flake/nixpkgs-stable): `2527da1e` -> `36bae450`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -597,11 +597,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724531977,
-        "narHash": "sha256-XROVLf9ti4rrNCFLr+DmXRZtPjCQTW4cYy59owTEmxk=",
+        "lastModified": 1724727824,
+        "narHash": "sha256-0XH9MJk54imJm+RHOLTUJ7e+ponLW00tw5ke4MTVa1Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2527da1ef492c495d5391f3bcf9c1dd9f4514e32",
+        "rev": "36bae45077667aff5720e5b3f1a5458f51cf0776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`08e5e55c`](https://github.com/NixOS/nixpkgs/commit/08e5e55c2a2e27e43ee3dab85828a3dac87ad705) | `` pretix: apply patch for CVE-2024-8113 ``                                                     |
| [`3e9a1b6c`](https://github.com/NixOS/nixpkgs/commit/3e9a1b6cafe678190a8509586027a3316b6812df) | `` maintainers: remove superherointj ``                                                         |
| [`49cc3841`](https://github.com/NixOS/nixpkgs/commit/49cc3841743a92d9af27e65d6a2fb094c7864581) | `` Kernel: update testing to 6.11-rc5 ``                                                        |
| [`ed6ca3c6`](https://github.com/NixOS/nixpkgs/commit/ed6ca3c6a89fc385ca4eebbcd397bd9015945b18) | `` forgejo-runner: 3.5.0 -> 3.5.1 ``                                                            |
| [`7c7a8c1a`](https://github.com/NixOS/nixpkgs/commit/7c7a8c1aeeefba20dbba70c4e5bb2a35c8f922b0) | `` forgejo-runner: 3.4.1 -> 3.5.0 ``                                                            |
| [`9608b32d`](https://github.com/NixOS/nixpkgs/commit/9608b32d810189b92a8d9878505264bcfd3fdc5d) | `` Discord updates ``                                                                           |
| [`3f6b5336`](https://github.com/NixOS/nixpkgs/commit/3f6b5336eb20bfbfad0943d8ca40bbcb86e78b10) | `` discord: 0.0.63 -> 0.0.64 ``                                                                 |
| [`53a72b6f`](https://github.com/NixOS/nixpkgs/commit/53a72b6f7d2262085d9dc05b25a12964884c6a59) | `` adwaita-icon-theme-legacy: init at 46.2 ``                                                   |
| [`81a75e9d`](https://github.com/NixOS/nixpkgs/commit/81a75e9d2ff3ff519efe69b931d6e8f1ddd0fa76) | `` gitlab: 17.2.2 -> 17.2.4 ``                                                                  |
| [`8e13b43d`](https://github.com/NixOS/nixpkgs/commit/8e13b43d94e2d41c5dd463e1d05e4ce2ef341093) | `` perlPackages.DBI: 1.643 -> 1.644 ``                                                          |
| [`5fda26f9`](https://github.com/NixOS/nixpkgs/commit/5fda26f950a00bb87e910aff03e6e4e1859d75a4) | `` deploy-rs: unstable-2024-02-16 -> 0-unstable-2024-06-12 ``                                   |
| [`fb3ed602`](https://github.com/NixOS/nixpkgs/commit/fb3ed6024c63cfb46de99baa23ecad230b5a74da) | `` deploy-rs: move to by-name ``                                                                |
| [`d5d2de09`](https://github.com/NixOS/nixpkgs/commit/d5d2de09313bed25683535645674b1d413c36981) | `` librewolf: 129.0.1-1 -> 129.0.2-1 ``                                                         |
| [`7d99e53b`](https://github.com/NixOS/nixpkgs/commit/7d99e53b65b4305632ba97670daa540f2019c3eb) | `` imagemagick: 7.1.1-36 -> 7.1.1-37 ``                                                         |
| [`83069d01`](https://github.com/NixOS/nixpkgs/commit/83069d01a613b11996729524a64ae4b89ea24cfe) | `` pnpm_9: 9.6.0 -> 9.7.0 ``                                                                    |
| [`1376fa54`](https://github.com/NixOS/nixpkgs/commit/1376fa54c2a6e02c99cf4f6da874fd1495d63ba8) | `` pnpm.fetchDeps: Add workspaces support and support for custom pnpm configuration commands `` |
| [`10481a20`](https://github.com/NixOS/nixpkgs/commit/10481a20563730c6d62838e1fdf66eb757185d06) | `` pnpm_{8,9}.fetchDeps: fix --ignore-scripts argument ``                                       |
| [`39d4d862`](https://github.com/NixOS/nixpkgs/commit/39d4d862a25544dd484120ac4849c9269aab7b1b) | `` pnpm_{8,9}.fetchDeps: put all pnpm install arguments in separate lines ``                    |
| [`5e5f785f`](https://github.com/NixOS/nixpkgs/commit/5e5f785fa9aaad68ecc1bfa316e1bfa49daa48b4) | `` pnpm_8: 8.15.8 -> 8.15.9 ``                                                                  |
| [`72b6b2e8`](https://github.com/NixOS/nixpkgs/commit/72b6b2e8f5977bb147ba47c009f6729eaa50874a) | `` pnpm_9: 9.4.0 -> 9.6.0 ``                                                                    |
| [`1e7d78a5`](https://github.com/NixOS/nixpkgs/commit/1e7d78a522ed72773d49ad26b4f64fb32b699ac5) | `` pnpm_9: 9.3.0 -> 9.4.0 ``                                                                    |
| [`0c8b42a5`](https://github.com/NixOS/nixpkgs/commit/0c8b42a51a8b7e5cef361fc7aa948f0002da4682) | `` pnpm.fetchDeps: error if lockfile version has a mismatch ``                                  |
| [`eb5d55b2`](https://github.com/NixOS/nixpkgs/commit/eb5d55b2af160665e5f5fe5381a2e14bc8ec09ee) | `` pnpm.fetchDeps: misc cleanup ``                                                              |
| [`7a627e33`](https://github.com/NixOS/nixpkgs/commit/7a627e3337f9e286af274b69d3b7cc84ebc7d4bd) | `` pnpm: install shell completions ``                                                           |
| [`1f011f99`](https://github.com/NixOS/nixpkgs/commit/1f011f99a6d61de0d17c725808666f90df310445) | `` pnpm: 9.1.1 -> 9.3.0 ``                                                                      |
| [`026b7704`](https://github.com/NixOS/nixpkgs/commit/026b770445fcb4b7de5d13b04d437830f441d8fe) | `` doc/javascript: pnpm: mention lack of monorepos/workspaces support ``                        |
| [`b05ae8fa`](https://github.com/NixOS/nixpkgs/commit/b05ae8faade5592fea2894f2a3395ac2217e107f) | `` pnpm_{8,9}: remove uneeded binary files from src ``                                          |
| [`b4f5b3fa`](https://github.com/NixOS/nixpkgs/commit/b4f5b3fa1a7dacceb2efc92ed42eeaf2971a7773) | `` pnpm.fetchDeps: add serve script ``                                                          |
| [`3f4a4d06`](https://github.com/NixOS/nixpkgs/commit/3f4a4d0672c4f5f0787f53b086a15be0067de88b) | `` pnpm.fetchDeps: init ``                                                                      |
| [`8fe4a3a9`](https://github.com/NixOS/nixpkgs/commit/8fe4a3a933fee677d79e5623b784df43194662d4) | `` pnpm: init at 9.1.1 ``                                                                       |
| [`57321d2e`](https://github.com/NixOS/nixpkgs/commit/57321d2ed2f5bbe6bfc32f23a2d219db1eef84a5) | `` nodePackages: enable overriding src and name attrs ``                                        |
| [`3226e7cd`](https://github.com/NixOS/nixpkgs/commit/3226e7cd5306ffa1903edd235460fa8680aa8c12) | `` librewolf-unwrapped: use settings from submodule ``                                          |
| [`bf04bfe6`](https://github.com/NixOS/nixpkgs/commit/bf04bfe620c2e99dab8d4c1755e96e077fe2368d) | `` bitwarden-desktop: 2024.6.4 -> 2024.8.0 ``                                                   |
| [`c5291d37`](https://github.com/NixOS/nixpkgs/commit/c5291d371009a4549f0fa9ae90af0c342c969cf3) | `` comet-gog: 0-unstable-2024-05-25 -> 0.1.2 ``                                                 |
| [`a511d56c`](https://github.com/NixOS/nixpkgs/commit/a511d56c97d07d0a97e7fbef4f1fc57537673a9a) | `` comet-gog: init at 0-unstable-2024-05-25 ``                                                  |
| [`1bf3945c`](https://github.com/NixOS/nixpkgs/commit/1bf3945cd47ea17526e7e359758c84fdbb9499ef) | `` webcord-vencord: electron_29 -> electron_30 ``                                               |
| [`2d7eef9f`](https://github.com/NixOS/nixpkgs/commit/2d7eef9fd7b152983f78c7669a16b0d46b210f70) | `` perlPackages.Appcpanminus: fix https hotpatch ``                                             |
| [`c7944362`](https://github.com/NixOS/nixpkgs/commit/c79443628569340d9f3e843e1b4581ad4924d36c) | `` nixos/tests/firewall: fix deprecation warning ``                                             |
| [`749b4b36`](https://github.com/NixOS/nixpkgs/commit/749b4b36d4e0559bd1458c50f62ced68df76ceed) | `` nixos/firewall: fix reverse path check failures with IPsec ``                                |
| [`2c8f6aa7`](https://github.com/NixOS/nixpkgs/commit/2c8f6aa77d72bb8f1d666ffc574c5147627766b7) | `` librewolf-unwrapped: add librewolf pref pane ``                                              |
| [`8e67536f`](https://github.com/NixOS/nixpkgs/commit/8e67536f766ec87dcc50e8c48b9deb27690606b0) | `` python311Packages.wagtail: 6.0.5 -> 6.0.6 ``                                                 |
| [`1ded7e15`](https://github.com/NixOS/nixpkgs/commit/1ded7e150fe5cad3dc13581b6f48efd2e8c27ef0) | `` suricata: 7.0.5 -> 7.0.6 ``                                                                  |
| [`0703a286`](https://github.com/NixOS/nixpkgs/commit/0703a286aede7c555b3f51e5eae5aca4e35d9d68) | `` mautrix-meta: 0.3.1 -> 0.3.2 ``                                                              |
| [`799b4451`](https://github.com/NixOS/nixpkgs/commit/799b4451fdd532610786f8b81b642767de3253c4) | `` lib.systems: throw if `sdkVer` or `ndkVer` are used for android. ``                          |
| [`b6e813b8`](https://github.com/NixOS/nixpkgs/commit/b6e813b8cdd7bbf4f447ec4c259c85155a5cf06f) | `` treewide: Rename android `sdkVer` and `ndkVer` ``                                            |
| [`98636237`](https://github.com/NixOS/nixpkgs/commit/98636237874295db2a5b8b46d784e74a783d74c5) | `` electron-chromedriver_31: 31.3.0 -> 31.4.0 ``                                                |
| [`fe1258de`](https://github.com/NixOS/nixpkgs/commit/fe1258de9ac3ed8c361e7daef17eb0e1fce6d0d2) | `` electron-chromedriver_31: 31.2.0 -> 31.3.0 ``                                                |
| [`7347b30e`](https://github.com/NixOS/nixpkgs/commit/7347b30e1947dbbcac9b6d4cd5c324f82bd92718) | `` electron: bump default version to v31 ``                                                     |
| [`f8aafeed`](https://github.com/NixOS/nixpkgs/commit/f8aafeed39ef3387b370914200b0666ca05166a5) | `` element-desktop: use electron version 31 ``                                                  |
| [`15c9b3b3`](https://github.com/NixOS/nixpkgs/commit/15c9b3b32e06c6aa5713d290f3fa11e08eb68371) | `` electron-bin: update maintainers ``                                                          |
| [`0e064ee0`](https://github.com/NixOS/nixpkgs/commit/0e064ee0a0a13e687b764cb8cc1595730189d3a5) | `` electron_31-bin: init at 31.4.0 ``                                                           |
| [`214cb05f`](https://github.com/NixOS/nixpkgs/commit/214cb05fbe4936bc6d78e2055eb72f22f896d877) | `` electron-source.electron_31: init at 31.4.0 ``                                               |
| [`3e0acfe0`](https://github.com/NixOS/nixpkgs/commit/3e0acfe09e3cdc59617c07f16659260d8bea9c67) | `` electron-source: fix update script for electron >=31 ``                                      |