### PR TITLE
chore(flake/spicetify-nix): `c8050c21` -> `6c7bd813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -780,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724818600,
-        "narHash": "sha256-7i8zqLTds2bXs6n/2ucSJdmKTzhajCktQ2WWFOVW3x0=",
+        "lastModified": 1724904972,
+        "narHash": "sha256-UuMf0oHOZqiU81WNSnk30XJ5sKYvvSiChvotptI1Zm0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c8050c21e2e61efe0ac2d423eac9062c62bb6633",
+        "rev": "6c7bd8132eb69880b7ec8935b6f55dbca1e69424",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`6c7bd813`](https://github.com/Gerg-L/spicetify-nix/commit/6c7bd8132eb69880b7ec8935b6f55dbca1e69424) | `` CI update 2024-08-29 `` |