### PR TITLE
chore(flake/zen-browser): `e1313b2d` -> `bc16bbb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,11 +890,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1724856811,
-        "narHash": "sha256-M5aWax0KbB8moT3KpnHewN0c3brVUoz5CLK12O668bo=",
+        "lastModified": 1724901719,
+        "narHash": "sha256-HXyeu2wwjQcymelWZs/7V7nHl/cvrt/bBKP+jpVa/YQ=",
         "owner": "MarceColl",
         "repo": "zen-browser-flake",
-        "rev": "e1313b2db7d3cd6c21d3dd2ecf8e5a0b5eebacde",
+        "rev": "bc16bbb32255566db797124065785eafd6e746a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`bc16bbb3`](https://github.com/MarceColl/zen-browser-flake/commit/bc16bbb32255566db797124065785eafd6e746a8) | `` bump version to 1.0.0-a.32 (#22) `` |