### PR TITLE
chore(flake/nixpkgs-stable): `36bae450` -> `ae2fc9e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -567,11 +567,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724727824,
-        "narHash": "sha256-0XH9MJk54imJm+RHOLTUJ7e+ponLW00tw5ke4MTVa1Y=",
+        "lastModified": 1724855419,
+        "narHash": "sha256-WXHSyOF4nBX0cvHN3DfmEMcLOVdKH6tnMk9FQ8wTNRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36bae45077667aff5720e5b3f1a5458f51cf0776",
+        "rev": "ae2fc9e0e42caaf3f068c1bfdc11c71734125e06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`a58b3c58`](https://github.com/NixOS/nixpkgs/commit/a58b3c5834f9d86e75c3cdc938070d153c5c9046) | `` departure-mono: init at 1.346 ``                                  |
| [`a4476dd7`](https://github.com/NixOS/nixpkgs/commit/a4476dd728544bffba6b03458754ebad01d1cf1d) | `` grafana: 10.4.7 -> 10.4.8 ``                                      |
| [`0019eff7`](https://github.com/NixOS/nixpkgs/commit/0019eff7c5ea861189670aa650b37dcdb8b63a10) | `` lx-music-desktop: 2.7.0 -> 2.8.0 ``                               |
| [`6a7538a6`](https://github.com/NixOS/nixpkgs/commit/6a7538a660994c6e644f56e2418cfcc0b704277e) | `` webtorrent_desktop: update and use latest electron (#320293) ``   |
| [`7e2c6684`](https://github.com/NixOS/nixpkgs/commit/7e2c6684ba59d65a85cd58ecd4799949818ffb3d) | `` webtorrent_desktop: make fetchpatch url reproducible ``           |
| [`8e4470a7`](https://github.com/NixOS/nixpkgs/commit/8e4470a74283aceb42d679947bc4340e693b1f74) | `` obsidian: remove reduant inherit ``                               |
| [`8992b4b4`](https://github.com/NixOS/nixpkgs/commit/8992b4b4573f299ed1f66792e43923ce6877f04f) | `` obsidian: add meta.mainProgram ``                                 |
| [`831e08a8`](https://github.com/NixOS/nixpkgs/commit/831e08a898293513bcba2a95e620579300ed6ef3) | `` obsidian: 1.6.5 -> 1.6.7 ``                                       |
| [`2e18df30`](https://github.com/NixOS/nixpkgs/commit/2e18df30b60a012e511912ef3ce3f7450b2e2ca2) | `` obsidian: 1.6.3 -> 1.6.5 ``                                       |
| [`17416ac0`](https://github.com/NixOS/nixpkgs/commit/17416ac0efd8f6b9458b0a5d6a1bb5f421cc0489) | `` obsidian: add commandLineArgs ``                                  |
| [`42f8839e`](https://github.com/NixOS/nixpkgs/commit/42f8839e0ecbba9ee64dd939ebc0e3d9d569fee7) | `` obsidian: removed electron version pin ``                         |
| [`871312f8`](https://github.com/NixOS/nixpkgs/commit/871312f892be7c2fe513ebb1da198b4c8f8501d7) | `` obsidian: update hash ``                                          |
| [`37177b61`](https://github.com/NixOS/nixpkgs/commit/37177b6182f400e44ce8c15b34640a37a5d2cad2) | `` obsidian: 1.5.12 -> 1.6.3 ``                                      |
| [`f7d1c7b9`](https://github.com/NixOS/nixpkgs/commit/f7d1c7b9f2448716e8fa5349cf50acae7b529db3) | `` feishin: 0.7.1 -> 0.7.3 ``                                        |
| [`1a11e462`](https://github.com/NixOS/nixpkgs/commit/1a11e462c1f3fe511e00da7fe04dd9461c5ac384) | `` feishin: move to pkgs/by-name ``                                  |
| [`8fbcdbc6`](https://github.com/NixOS/nixpkgs/commit/8fbcdbc68dbd2f6974f7142ec4184fe4841e59c8) | `` ride: add patch to support later electron versions ``             |
| [`b2a845d7`](https://github.com/NixOS/nixpkgs/commit/b2a845d7eeb122aeb75e1dc6e28b17b1bc7ab7b0) | `` blockbench: remove electron version pin ``                        |
| [`3854dde4`](https://github.com/NixOS/nixpkgs/commit/3854dde46568dd58c0b42aa6e28912e37401bdd6) | `` antares: 0.7.24 -> 0.7.28 ``                                      |
| [`1a42560e`](https://github.com/NixOS/nixpkgs/commit/1a42560e0d113dbdafac67fe36ee48aaa833809a) | `` yarn2nix: remove GPLv3 licence ``                                 |
| [`361c1e5c`](https://github.com/NixOS/nixpkgs/commit/361c1e5c2aa6cf3c5e2c34b245c3f7623921f461) | `` eris-go: 20240128 -> 20240826 ``                                  |
| [`665a1853`](https://github.com/NixOS/nixpkgs/commit/665a1853b5523c35872ccc16054c6f2484a19e15) | `` nixos/eris-server: update comment ``                              |
| [`a4eae086`](https://github.com/NixOS/nixpkgs/commit/a4eae08694c9c88773d3d2c9a7e11bb9f1f43dad) | `` hydra_unstable: Fix CVE-2024-45049 ``                             |
| [`f44a0b4e`](https://github.com/NixOS/nixpkgs/commit/f44a0b4e110e512a3d796e5749cbe67cdb01fd57) | `` picosnitch: mark as vulnerable ``                                 |
| [`691e0952`](https://github.com/NixOS/nixpkgs/commit/691e09524a7c798040225c6c93812e1fa6ceabfa) | `` nixos/varnish: change default stateDir to /run ``                 |
| [`c4205633`](https://github.com/NixOS/nixpkgs/commit/c4205633715ec541d62a55f36345e93fe5e48187) | `` signal-desktop: replace unlicensed Apple emoji ``                 |
| [`2e7721ba`](https://github.com/NixOS/nixpkgs/commit/2e7721ba4d887893e7c6f958a419aaf76039f803) | `` signal-desktop: add myself to maintainers ``                      |
| [`528398da`](https://github.com/NixOS/nixpkgs/commit/528398da643ebc0695264f32853c4b96a05a7091) | `` netbird: 0.28.8 -> 0.28.9 ``                                      |
| [`29e54dda`](https://github.com/NixOS/nixpkgs/commit/29e54dda68d2807998c86365f65f5eba0c3a46c8) | `` maintainer: add vrifox ``                                         |
| [`e4066581`](https://github.com/NixOS/nixpkgs/commit/e4066581c7245ce574c43f1afc6702d868c42923) | `` simplex-chat-desktop: 5.8.1 -> 6.0.3 ``                           |
| [`fdd1865a`](https://github.com/NixOS/nixpkgs/commit/fdd1865a4853bcc5f713bb0fe9c34ac5a682e386) | `` morgen: electron_29 -> electron_30 ``                             |
| [`1620cf62`](https://github.com/NixOS/nixpkgs/commit/1620cf62264da436a4d527662b1f209004031f2d) | `` morgen: 3.5.1 -> 3.5.5 ``                                         |
| [`04113f1c`](https://github.com/NixOS/nixpkgs/commit/04113f1cde36c2ee1218b688eb920ddc28713bb0) | `` morgen: 3.4.5 -> 3.5.1 ``                                         |
| [`f99b0ce1`](https://github.com/NixOS/nixpkgs/commit/f99b0ce108efc10e47dc729237b4e3247371dd79) | `` morgen: 3.4.4 -> 3.4.5 ``                                         |
| [`ed32d0ab`](https://github.com/NixOS/nixpkgs/commit/ed32d0ab100308107975288533eb42c818a1bbe3) | `` morgen: electron_28 -> electron_29 ``                             |
| [`4cefad5a`](https://github.com/NixOS/nixpkgs/commit/4cefad5a46f18256953b885dfa982c559e36fc69) | `` morgen: 3.4.3 -> 3.4.4 ``                                         |
| [`1bae4c84`](https://github.com/NixOS/nixpkgs/commit/1bae4c84ee430f046d55453cb4c84486bade05fd) | `` morgen: 3.4.2 -> 3.4.3 ``                                         |
| [`3f59c6a2`](https://github.com/NixOS/nixpkgs/commit/3f59c6a2e8c5999678b75f6a3dcc01f624c1c28d) | `` heroic: 2.14.1 -> 2.15.1 ``                                       |
| [`2437b36c`](https://github.com/NixOS/nixpkgs/commit/2437b36cdac87e85a1a4e20b04325c8d32ccd11b) | `` heroic: add icu to FHS env ``                                     |
| [`ec4dd6d7`](https://github.com/NixOS/nixpkgs/commit/ec4dd6d792601e092d383d7f6e177c9a17239ac6) | `` tests/lomiri-camera-app: Fix backported test ``                   |
| [`669d0c9d`](https://github.com/NixOS/nixpkgs/commit/669d0c9dea216f3a37d289ff4174abdead850b7c) | `` nixos/lomiri: Add gallery app ``                                  |
| [`d8667755`](https://github.com/NixOS/nixpkgs/commit/d86677556f87e20dc84f2f12647c242db808ae97) | `` tests/lomiri-gallery-app: init ``                                 |
| [`60ac12a4`](https://github.com/NixOS/nixpkgs/commit/60ac12a4f89e8488f4f60bd851a94369042a5658) | `` lomiri.lomiri-gallery-app: init at 3.0.2 ``                       |
| [`987f6a5b`](https://github.com/NixOS/nixpkgs/commit/987f6a5bf2b05b29409183c2981f65153dd77251) | `` nixos/systemd/initrd: Fix emergencyAccess to work with `null`. `` |
| [`1c569a5b`](https://github.com/NixOS/nixpkgs/commit/1c569a5b35c7ec654726a484bd371b1b6b7f9039) | `` microsoft-edge: 126.0.2592.113 -> 127.0.2651.86 ``                |
| [`b4d7df70`](https://github.com/NixOS/nixpkgs/commit/b4d7df70abaeb6e5dbff8ce72fcc7f6a058b0728) | `` microsoft-edge: 126.0.2592.102 -> 126.0.2592.113 ``               |
| [`67f4b241`](https://github.com/NixOS/nixpkgs/commit/67f4b241a1d11c2152c9833956d5ebbf55b9aa5b) | `` python312Packages.lib4sbom: refactor ``                           |
| [`952e12f3`](https://github.com/NixOS/nixpkgs/commit/952e12f3801ced9c586954b81bd0c05d71cb41c7) | `` python312Packages.lib4sbom: add changelog to meta ``              |
| [`653d110f`](https://github.com/NixOS/nixpkgs/commit/653d110f68f1113383afba8797a24dddb156dcf1) | `` python312Packages.lib4sbom: 0.7.2 -> 0.7.3 ``                     |