### PR TITLE
chore(flake/zen-browser): `bc16bbb3` -> `cfc894ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -839,11 +839,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1724901719,
-        "narHash": "sha256-HXyeu2wwjQcymelWZs/7V7nHl/cvrt/bBKP+jpVa/YQ=",
+        "lastModified": 1725096998,
+        "narHash": "sha256-ylP5YehroiFnf1AIT5yq1mcc8HUVlj9ItsWCtY6J6ck=",
         "owner": "MarceColl",
         "repo": "zen-browser-flake",
-        "rev": "bc16bbb32255566db797124065785eafd6e746a8",
+        "rev": "cfc894abb631e3ea61ff590b7520d79d35a26366",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`cfc894ab`](https://github.com/MarceColl/zen-browser-flake/commit/cfc894abb631e3ea61ff590b7520d79d35a26366) | `` update version to 1.0.0-a.34 (#26) `` |
| [`06af05ac`](https://github.com/MarceColl/zen-browser-flake/commit/06af05acbaf5fa72b54f8c6f109b1ed153d095af) | `` update version to 1.0.0-a.33 (#25) `` |