### PR TITLE
chore(flake/nixpkgs-stable): `ae2fc9e0` -> `6e99f2a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724855419,
-        "narHash": "sha256-WXHSyOF4nBX0cvHN3DfmEMcLOVdKH6tnMk9FQ8wTNRc=",
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae2fc9e0e42caaf3f068c1bfdc11c71734125e06",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`6e99f2a2`](https://github.com/NixOS/nixpkgs/commit/6e99f2a27d600612004fbd2c3282d614bfee6421) | `` [Backport release-24.05] openvpn-auth-ldap: Fix CVE-2024-28820 (#338216) `` |
| [`3fed149a`](https://github.com/NixOS/nixpkgs/commit/3fed149ae547398f59fb895bad69e319fb1d9308) | `` linux_6_1: 6.1.106 -> 6.1.107 ``                                            |
| [`1caf8bfb`](https://github.com/NixOS/nixpkgs/commit/1caf8bfb4d3b1c69f10a6fa7d67aafb54dc735e9) | `` linux_6_6: 6.6.47 -> 6.6.48 ``                                              |
| [`c539074b`](https://github.com/NixOS/nixpkgs/commit/c539074b157914813b37bffddd1a0754c47ea201) | `` linux_6_10: 6.10.6 -> 6.10.7 ``                                             |
| [`fa105073`](https://github.com/NixOS/nixpkgs/commit/fa105073ab2781053d3e86a49af85c3fe902aaae) | `` ungoogled-chromium: 128.0.6613.84-1 -> 128.0.6613.113-1 ``                  |
| [`88940ce4`](https://github.com/NixOS/nixpkgs/commit/88940ce4f1c20b438e624b41bd09b4b030456873) | `` gsoap: fix cross compilation ``                                             |
| [`009f9315`](https://github.com/NixOS/nixpkgs/commit/009f9315f9b34043bfb3a4a1f6a73d35a39120bb) | `` chromium,chromedriver: 128.0.6613.84 -> 128.0.6613.113 ``                   |
| [`02e787ce`](https://github.com/NixOS/nixpkgs/commit/02e787cec806e8c0a7ec2c6002bd0a8f614cecf7) | `` thunderbirdPackages.thunderbird-115: 115.13.0 -> 115.14.0 ``                |
| [`8308f7dc`](https://github.com/NixOS/nixpkgs/commit/8308f7dce4f5bce0f650324d4ce8d5f24897996c) | `` signal-desktop: 7.21.0 -> 7.22.0, beta: 7.19.0-beta.1 -> 7.23.0-beta.1 ``   |
| [`261db25a`](https://github.com/NixOS/nixpkgs/commit/261db25a2d554b915ec107b0161b9467de1d675c) | `` teams-for-linux: 1.4.27 -> 1.9.5 ``                                         |
| [`889ce5b2`](https://github.com/NixOS/nixpkgs/commit/889ce5b2c82e72ab1d720076295a343fa345d3dc) | `` teams-for-linux: add khaneliman maintainer ``                               |
| [`1075a62a`](https://github.com/NixOS/nixpkgs/commit/1075a62a0356802d3bfd39d5165fb578de1846d4) | `` teams-for-linux: move to by-name ``                                         |
| [`40d73c78`](https://github.com/NixOS/nixpkgs/commit/40d73c784cb38c94da6f5324fe83a69168aeaa66) | `` teams-for-linux: fmt ``                                                     |
| [`3fda3e13`](https://github.com/NixOS/nixpkgs/commit/3fda3e130ecdae87bfb2b2e0ee7a9e6a3c1f5b6e) | `` bitwarden-desktop: ensure no unfree source is used ``                       |
| [`71132380`](https://github.com/NixOS/nixpkgs/commit/7113238008da1815b9b5c7193f4164ea5d392487) | `` bitwarden-desktop: 2024.8.0 -> 2024.8.1 ``                                  |
| [`9d0e4143`](https://github.com/NixOS/nixpkgs/commit/9d0e41430ac6daa89cf07d4cc4cf0763c29d8b5d) | `` kanidm: require big-parallel for building ``                                |
| [`3066eafe`](https://github.com/NixOS/nixpkgs/commit/3066eafe80edff1e5e07de48dc33147b6344f73a) | `` canon-cups-ufr2: 5.70 -> 5.90 ``                                            |
| [`d9cb5180`](https://github.com/NixOS/nixpkgs/commit/d9cb51800cd03bbf85c8e31f840d242f108c7a92) | `` uwsm: 0.18.0 -> 0.18.2 ``                                                   |
| [`98b25eb0`](https://github.com/NixOS/nixpkgs/commit/98b25eb0c7be0ea06aed734aeed3642316037220) | `` uwsm: 0.17.4 -> 0.18.0 ``                                                   |
| [`bb9ef197`](https://github.com/NixOS/nixpkgs/commit/bb9ef197f3409a352b9f6f91759b40096ca7705c) | `` uwsm: 0.17.2 -> 0.17.4 ``                                                   |
| [`444d1181`](https://github.com/NixOS/nixpkgs/commit/444d11818a3af6191d2a17bec33471438e51b1e6) | `` uwsm: also wrap sway and hyprland's paths ``                                |
| [`bf54a4c4`](https://github.com/NixOS/nixpkgs/commit/bf54a4c45a2ab5d0aec01641969acf9998e9d09c) | `` uwsm: fix dependencies add wrap the binary as well ``                       |
| [`12d6d4cf`](https://github.com/NixOS/nixpkgs/commit/12d6d4cf38e22d885410c436be97a1f096d68eb5) | `` uwsm: 0.17.0 -> 0.17.2 ``                                                   |
| [`0ec42ae1`](https://github.com/NixOS/nixpkgs/commit/0ec42ae1d58e76f463b6510706a33b1c785470ff) | `` uwsm: add kai-tub to maintainers ``                                         |
| [`5a1c3f55`](https://github.com/NixOS/nixpkgs/commit/5a1c3f5557ddfc7eee8ba5c75f7063c76db6564b) | `` feishin: use electron_31 ``                                                 |
| [`21a75e09`](https://github.com/NixOS/nixpkgs/commit/21a75e0916edc7268ac0b7aad178a800304e4ab1) | `` feishin: change `${pname}` to string literal ``                             |
| [`3a204ea6`](https://github.com/NixOS/nixpkgs/commit/3a204ea666b29ba2215f911825299c8997554a60) | `` feishin: upgrade electron to v30 ``                                         |
| [`f802ba42`](https://github.com/NixOS/nixpkgs/commit/f802ba42413aaf90d0b87821e39c20fbbfcbff68) | `` lx-music-desktop: 2.8.0 -> 2.9.0 ``                                         |
| [`3f2a98cf`](https://github.com/NixOS/nixpkgs/commit/3f2a98cf4bf267fe86553712ae46a3b20d2ce321) | `` electron-source.electron_29: remove as it's EOL ``                          |
| [`35f64ff5`](https://github.com/NixOS/nixpkgs/commit/35f64ff5b864b8bac6717044f423a37f54f02998) | `` electron_29-bin: mark as insecure because it's EOL ``                       |
| [`7ec0f645`](https://github.com/NixOS/nixpkgs/commit/7ec0f64595a06e3e28b2fc42c3fe4aeba67aa2dd) | `` electron-chromedriver_30: 30.3.1 -> 30.4.0 ``                               |
| [`fc3ced2a`](https://github.com/NixOS/nixpkgs/commit/fc3ced2a81a2dfbe3a968c142deb8735161b3f51) | `` electron-chromedriver_29: 29.4.5 -> 29.4.6 ``                               |
| [`dd14c65b`](https://github.com/NixOS/nixpkgs/commit/dd14c65b45ce38bd5ed6e6cfa2fa3a3b81ff86b9) | `` electron-source.electron_30: 30.3.1 -> 30.4.0 ``                            |
| [`0a3e926a`](https://github.com/NixOS/nixpkgs/commit/0a3e926ad3ab751b19b8c4bc021ac0915554f90e) | `` electron-source.electron_29: 29.4.5 -> 29.4.6 ``                            |
| [`00837607`](https://github.com/NixOS/nixpkgs/commit/0083760702e7212c1f4342ba247e1c8b3a461971) | `` electron_30-bin: 30.3.1 -> 30.4.0 ``                                        |
| [`c08e34ab`](https://github.com/NixOS/nixpkgs/commit/c08e34aba1627c6332e68c1c652de324bbdd5bdc) | `` electron_29-bin: 29.4.5 -> 29.4.6 ``                                        |
| [`953a5b7c`](https://github.com/NixOS/nixpkgs/commit/953a5b7cdc8b83a0a176c11cbc3bb43f678542d7) | `` chromium,electron-source: remove no longer needed version conditionals ``   |
| [`9cf01721`](https://github.com/NixOS/nixpkgs/commit/9cf01721658ad0dbfac6014ef1420ca9c64b3dda) | `` koboldcpp: 1.73 -> 1.73.1 ``                                                |
| [`a228cccb`](https://github.com/NixOS/nixpkgs/commit/a228cccb762a5163b7aaaff335dadfddfd985f45) | `` koboldcpp: sort meta and add changelog ``                                   |
| [`15a2bb6d`](https://github.com/NixOS/nixpkgs/commit/15a2bb6d13896304598c87f99a392f3cee093807) | `` koboldcpp: 1.72 -> 1.73 ``                                                  |
| [`738281b6`](https://github.com/NixOS/nixpkgs/commit/738281b62d805eb26dcd3aae023103b3975ea82e) | `` powerpipe: 0.4.2 -> 0.4.3 ``                                                |
| [`6d175be5`](https://github.com/NixOS/nixpkgs/commit/6d175be58f6b3bc03c221c07e038f43c13c13fe9) | `` electron-source.electron_{27,28}: remove instead of marking them as EOL ``  |
| [`3ed9728d`](https://github.com/NixOS/nixpkgs/commit/3ed9728d5cf3717daf1c57a412e1bd191be8977a) | `` electron*: mark older versions as EOL ``                                    |
| [`ce076366`](https://github.com/NixOS/nixpkgs/commit/ce0763669f527f5984a590f416964872403787d9) | `` knot-dns: 3.3.8 -> 3.3.9 ``                                                 |
| [`404584d5`](https://github.com/NixOS/nixpkgs/commit/404584d54d5d1179b1a24627ffd1b5edbbcdb2a7) | `` thunderbird-unwrapped: 128.1.0esr -> 128.1.1esr ``                          |
| [`b67636a4`](https://github.com/NixOS/nixpkgs/commit/b67636a4b13b835861180e69c71a3b2600b17fce) | `` flyctl: 0.2.114 -> 0.2.120 ``                                               |
| [`0892020c`](https://github.com/NixOS/nixpkgs/commit/0892020c56829e4fe511e338ef13ef0d21173ba6) | `` i2p: 2.5.1 -> 2.6.1 ``                                                      |
| [`e40e5d08`](https://github.com/NixOS/nixpkgs/commit/e40e5d0871d258c4e9c1322f91e54640157fda09) | `` buildkite-agent: 3.76.2 -> 3.77.0 ``                                        |
| [`5db23275`](https://github.com/NixOS/nixpkgs/commit/5db2327502d220e815be6ca48099266684160d31) | `` buildkite-agent: 3.76.1 -> 3.76.2 ``                                        |
| [`e6a019c9`](https://github.com/NixOS/nixpkgs/commit/e6a019c9140d4893858365e99494dd0e1a5974d1) | `` buildkite-agent: 3.59.0 -> 3.76.1 ``                                        |
| [`e3fa245e`](https://github.com/NixOS/nixpkgs/commit/e3fa245e259b627523ebe1f5ebd94e7f7aafec54) | `` buildkite-agent: move to by-name ``                                         |
| [`8b7a8508`](https://github.com/NixOS/nixpkgs/commit/8b7a8508d059a10e3eaa4a73c4e463ca2c818b25) | `` microcodeIntel: 20240531 -> 20240813 ``                                     |