### PR TITLE
chore(flake/plasma-manager): `5c97fe8a` -> `c0026190`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724556439,
-        "narHash": "sha256-gPR3sxkKxISUvydnqoj54znpUkK8av/HVFuFJuYUw3w=",
+        "lastModified": 1725210710,
+        "narHash": "sha256-HHWEeLhfDeprabbxjGc/jVWpUu0+gFaQ0jWgohe02XE=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "5c97fe8af2a2e561f14195ed357d8c451fdbff4c",
+        "rev": "c00261909b44a960894552bbeafb762af2fa9bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                 |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`c0026190`](https://github.com/nix-community/plasma-manager/commit/c00261909b44a960894552bbeafb762af2fa9bd8) | `` Add module for Ghostwriter (#342) `` |