### PR TITLE
chore(flake/spicetify-nix): `305b6034` -> `0f66eb16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725077747,
-        "narHash": "sha256-4SwFxe789QXOtGNFbwldpqFzkKxIFuyDysFttFWB5eM=",
+        "lastModified": 1725250580,
+        "narHash": "sha256-OJ123JRnfuTYp0FYcQuFGvSB9uxw41sIJS6ojStUEkI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "305b6034ad329268eb33c079e2d33740ccf329ea",
+        "rev": "0f66eb16c0cb63406b8477740ffd41e4e0c301a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`0f66eb16`](https://github.com/Gerg-L/spicetify-nix/commit/0f66eb16c0cb63406b8477740ffd41e4e0c301a1) | `` CI update 2024-09-02 `` |
| [`be4c6a86`](https://github.com/Gerg-L/spicetify-nix/commit/be4c6a86cd30f29c847412cf4d3463c3113e3c30) | `` CI update 2024-09-01 `` |