### PR TITLE
chore(flake/sops-nix): `be0eec2d` -> `5db5921e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723501126,
-        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
+        "lastModified": 1725201042,
+        "narHash": "sha256-lj5pxOwidP0W//E7IvyhbhXrnEUW99I07+QpERnzTS4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
+        "rev": "5db5921e40ae382d6716dce591ea23b0a39d96f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`5db5921e`](https://github.com/Mic92/sops-nix/commit/5db5921e40ae382d6716dce591ea23b0a39d96f7) | `` Reuse the existing nixpkgs instance for the tests instead of re-importing it (#611) `` |
| [`2acfc17e`](https://github.com/Mic92/sops-nix/commit/2acfc17e8cecc8812fd1834d008d6456e6d65135) | `` update vendorHash ``                                                                   |
| [`855c42b2`](https://github.com/Mic92/sops-nix/commit/855c42b2b8a351e11d59c11b810f2b199961c936) | `` build(deps): bump golang.org/x/sys from 0.23.0 to 0.24.0 ``                            |