### PR TITLE
chore(flake/nixpkgs-stable): `6e99f2a2` -> `6f6c45b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725001927,
-        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
+        "lastModified": 1725407940,
+        "narHash": "sha256-tiN5Rlg/jiY0tyky+soJZoRzLKbPyIdlQ77xVgREDNM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
+        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`6631a2fd`](https://github.com/NixOS/nixpkgs/commit/6631a2fd89dcad3c3900462a367c957fd1400548) | `` linux_xanmod_latest: 6.10.6 -> 6.10.7 ``                                      |
| [`d807afc5`](https://github.com/NixOS/nixpkgs/commit/d807afc5a16755872ab84b36f5df1814c43385ba) | `` linux_xanmod: 6.6.47 -> 6.6.48 ``                                             |
| [`e2cc0374`](https://github.com/NixOS/nixpkgs/commit/e2cc0374eaa67173b3f67b698446f1c51860db96) | `` linux_xanmod_latest: 6.10.5 -> 6.10.6 ``                                      |
| [`09c75b36`](https://github.com/NixOS/nixpkgs/commit/09c75b362555a5dc7f86c9ccb51941a73f644473) | `` linux_xanmod: 6.6.46 -> 6.6.47 ``                                             |
| [`34bd6f44`](https://github.com/NixOS/nixpkgs/commit/34bd6f4481b80d774ef237aeebbf55faa69aaa62) | `` nss_latest: 3.103 -> 3.104 ``                                                 |
| [`db4e63a4`](https://github.com/NixOS/nixpkgs/commit/db4e63a4e2570301c56c4a3e892690343562b036) | `` nixos/prowlarr: set HOME for the service ``                                   |
| [`20b6f6fa`](https://github.com/NixOS/nixpkgs/commit/20b6f6fa5f8b83710bd3de33ed255f480e8b12e4) | `` emacsPackages.p4-16-mode: fix build ``                                        |
| [`4d3c4435`](https://github.com/NixOS/nixpkgs/commit/4d3c44350c63896ab14e1196d8d5bda9380b9010) | `` matrix-synapse-unwrapped: 1.113.0 -> 1.114.0 ``                               |
| [`47f20526`](https://github.com/NixOS/nixpkgs/commit/47f2052602b81b971b918dfe053c3766399d74d7) | `` nss_latest: 3.102.1 -> 3.103 ``                                               |
| [`ad4cf138`](https://github.com/NixOS/nixpkgs/commit/ad4cf138ab876f7773d722e8bd8aa24796b719ec) | `` imagemagick: 7.1.1-37 -> 7.1.1-38 ``                                          |
| [`76e9677e`](https://github.com/NixOS/nixpkgs/commit/76e9677e71bab56729450a0202b60ecbe5b90716) | `` google-chrome: 128.0.6613.84 -> 128.0.6613.113 ``                             |
| [`79237d02`](https://github.com/NixOS/nixpkgs/commit/79237d02b4ae546b8e8b323808760b2c18b37c2c) | `` OVMF: fix building for riscv64 ``                                             |
| [`9d5a3635`](https://github.com/NixOS/nixpkgs/commit/9d5a3635a3eeceefeb223639e3c880526c41edc3) | `` linux-rt_6_6: 6.6.44-rt39 -> 6.6.48-rt40 ``                                   |
| [`7e53334d`](https://github.com/NixOS/nixpkgs/commit/7e53334d818e91a27d3ec55899d61ec37559a197) | `` linux-rt_6_1: 6.1.105-rt38 -> 6.1.107-rt39 ``                                 |
| [`ee03d9f0`](https://github.com/NixOS/nixpkgs/commit/ee03d9f0b66683923d9b5656179c120cfe9f7916) | `` linux_testing: 6.11-rc5 -> 6.11-rc6 ``                                        |
| [`a127e601`](https://github.com/NixOS/nixpkgs/commit/a127e601a5766338506053630285fa357f484861) | `` zenmonitor: 2.0.0 -> unstable-2024-05-21 and new src ``                       |
| [`b29c4981`](https://github.com/NixOS/nixpkgs/commit/b29c4981f2a768a6845fd689fb23ca6aed5d103e) | `` stargazer: 1.2.2 -> 1.2.3 ``                                                  |
| [`caef9784`](https://github.com/NixOS/nixpkgs/commit/caef9784ece5547c44490ec682451931bd332ad1) | `` python3Packages.matrix-nio: add `withOlm` flag ``                             |
| [`832d1774`](https://github.com/NixOS/nixpkgs/commit/832d17740d6a7319bd00151f756781ee51852a96) | `` python3Packages.mautrix: add `withOlm` flag ``                                |
| [`13b44b35`](https://github.com/NixOS/nixpkgs/commit/13b44b351ed7ecc6d52b2490a418bb0d5751d139) | `` python3Packages.mautrix: use `pyproject` ``                                   |
| [`b4709e01`](https://github.com/NixOS/nixpkgs/commit/b4709e010fe18ace9aab91e5daf521b31afe559f) | `` roundcube: 1.6.8 -> 1.6.9 ``                                                  |
| [`580de4d1`](https://github.com/NixOS/nixpkgs/commit/580de4d195375b4ba0a1fdb16e03ea26a1a5bfa4) | `` nixos/invidious: remove machine.config in test ``                             |
| [`283bcc08`](https://github.com/NixOS/nixpkgs/commit/283bcc08b6b6e49f5848291c37545ad1915dd750) | `` invidious: 2.20240427 -> 2.20240825.2 ``                                      |
| [`c6c13354`](https://github.com/NixOS/nixpkgs/commit/c6c133545e83a39f126c2d6b67794649b940fb52) | `` invidious: fix update script ``                                               |
| [`3e69f407`](https://github.com/NixOS/nixpkgs/commit/3e69f407b9e3854eb2eef8e8f1d4d3fc7e34077b) | `` invidious: switch to github repo ``                                           |
| [`f4450fa5`](https://github.com/NixOS/nixpkgs/commit/f4450fa5a7e935ea71a78c52f408ac4e509e4fa5) | `` mautrix-{meta,signal,whatsapp}: Optionally build against goolm ``             |
| [`cc0efe8f`](https://github.com/NixOS/nixpkgs/commit/cc0efe8f5866a26966167b6912786b57745a7f7d) | `` discord: various updates (#338785) ``                                         |
| [`8c7565b0`](https://github.com/NixOS/nixpkgs/commit/8c7565b02328b2ddebd64c313d1492c1e4a1944e) | `` discord: 0.0.65 -> 0.0.66 ``                                                  |
| [`800195d3`](https://github.com/NixOS/nixpkgs/commit/800195d35fe179e21f21257c134097f70245b89d) | `` flyctl: 0.2.120 -> 0.2.124 ``                                                 |
| [`c7197aab`](https://github.com/NixOS/nixpkgs/commit/c7197aab04f5a73bc80180888fb3fdfd94d536c9) | `` erigon: 2.60.0 -> 2.60.6 ``                                                   |
| [`43e77c3a`](https://github.com/NixOS/nixpkgs/commit/43e77c3a5fdbb1fc7708b42c1bc7f544eb6973f7) | `` nixos/telegraf: make sure ping executable is available when trying to ping `` |
| [`ba7ff1d1`](https://github.com/NixOS/nixpkgs/commit/ba7ff1d171a08f472c940a51b64931cb9819a951) | `` python313: 3.13.0b4 -> 3.13.0rc1 ``                                           |
| [`d8295132`](https://github.com/NixOS/nixpkgs/commit/d8295132355fc8b19871d56c4859548cf83275df) | `` nixos/iso-image: Compress squashfs with zstd 19 ``                            |
| [`8931f18b`](https://github.com/NixOS/nixpkgs/commit/8931f18bfaf75e25009b9028657e18de334fe2c5) | `` nixos/fcgiwrap: add security advisory links to messages ``                    |
| [`d6c74c5a`](https://github.com/NixOS/nixpkgs/commit/d6c74c5ab76c8b103a2b2ebef976b778b286cf8c) | `` php82: 8.2.22 -> 8.2.23 ``                                                    |
| [`1f327da5`](https://github.com/NixOS/nixpkgs/commit/1f327da5f54ba98b8e7104b7000a42e99efac72e) | `` php: 8.2.21 -> 8.2.22 ``                                                      |
| [`6a74b22f`](https://github.com/NixOS/nixpkgs/commit/6a74b22fb8ff9d1104ed5f85e186c8aebaf4ed42) | `` php83: 8.3.10 -> 8.3.11 ``                                                    |
| [`e14a73a4`](https://github.com/NixOS/nixpkgs/commit/e14a73a48fbf880e512f3b50ac3273ad408c34da) | `` php83: 8.3.9 -> 8.3.10 ``                                                     |
| [`d05b6e35`](https://github.com/NixOS/nixpkgs/commit/d05b6e35734e5555bd071d03752c1e4fd267db46) | `` ceph.tests: Fix maintainer eval ``                                            |
| [`31e49512`](https://github.com/NixOS/nixpkgs/commit/31e495125b71cd77b90f99e0cb4e19f3b97ed217) | `` tests/ceph: bluestore, dmcrypt, and IPv6 test ``                              |
| [`5710927e`](https://github.com/NixOS/nixpkgs/commit/5710927e82c006a168a212c51d9165c5abd5cd66) | `` ceph: Fix missing patch for Ceph with dmcrypt. Fixes #334975 ``               |
| [`c5b65fe0`](https://github.com/NixOS/nixpkgs/commit/c5b65fe0d533e6b70352b6fa1d84d3e71bdde91c) | `` ceph: Add patch to fix broken cryptsetup version parsing. Fixes #334227 ``    |
| [`e71c31fd`](https://github.com/NixOS/nixpkgs/commit/e71c31fd1b25486cb9641a074473d9f8e7c2e5b0) | `` ceph: Add patch to fix Python `packaging` import (runtime semi-crash). ``     |
| [`50026240`](https://github.com/NixOS/nixpkgs/commit/500262409138d999343f6c2e496e35646359f278) | `` ceph: fix build ``                                                            |
| [`1974ec95`](https://github.com/NixOS/nixpkgs/commit/1974ec95e3e70e0e96d1f5e28c70a78a1c43fc8e) | `` stats: 2.11.4 -> 2.11.7 ``                                                    |
| [`10b291be`](https://github.com/NixOS/nixpkgs/commit/10b291bed30b4ad09a02ece0a9b78dcc4e84bb25) | `` libnbd: 1.20.1 -> 1.20.2 ``                                                   |
| [`06f99fb5`](https://github.com/NixOS/nixpkgs/commit/06f99fb537accd088238b01287c5531d6b81feae) | `` litestream: add CVE-2024-41254 to knownVulnerabilities ``                     |
| [`8c5720cf`](https://github.com/NixOS/nixpkgs/commit/8c5720cf6127c283993b5ad944b540499656e95c) | `` python313: 3.13.0b3 -> 3.13.0b4 ``                                            |
| [`f0bfce09`](https://github.com/NixOS/nixpkgs/commit/f0bfce09e09d67b7ca60e9177d953975892bb805) | `` microsoft-edge: 127.0.2651.86 -> 128.0.2739.42 ``                             |
| [`41e7bbd2`](https://github.com/NixOS/nixpkgs/commit/41e7bbd2ddd55b66c63a30c977b59d52aececcbd) | `` mattermost: 9.5.8 -> 9.5.9 ``                                                 |
| [`11e73328`](https://github.com/NixOS/nixpkgs/commit/11e7332807fa4acf95d73c1a64c8723a9c41e678) | `` olm: update vulnerability description ``                                      |
| [`1e88a008`](https://github.com/NixOS/nixpkgs/commit/1e88a008bac3a1caa6f410150039cf9d3c72177c) | `` matomo_5: 5.1.0 -> 5.1.1 ``                                                   |
| [`d09ca3c2`](https://github.com/NixOS/nixpkgs/commit/d09ca3c2a2653b4cb723e163d95b5305e90f58b7) | `` matomo_5: 5.0.2 -> 5.1.0 ``                                                   |
| [`b5b154eb`](https://github.com/NixOS/nixpkgs/commit/b5b154eba1ba6a14b75a257bfc0a0aeaf50b15ad) | `` maintainers: add laalsaas to FC team ``                                       |
| [`425cf7c4`](https://github.com/NixOS/nixpkgs/commit/425cf7c45049d67e3308822f49cf865dd18a5306) | `` _389-ds-base: 2.4.5 -> 2.4.6 ``                                               |
| [`cd160d3e`](https://github.com/NixOS/nixpkgs/commit/cd160d3e54a695f7d90a810e0aea659ce2dc6003) | `` forgejo: 7.0.7 -> 7.0.8 ``                                                    |
| [`0bb2e842`](https://github.com/NixOS/nixpkgs/commit/0bb2e8423f52b804d720a1a736d61a36c73ecd6c) | `` skypeforlinux: 8.126.0.208 -> 8.127.0.200 ``                                  |
| [`66423ba4`](https://github.com/NixOS/nixpkgs/commit/66423ba4eff01db42b20b311add9137e8002c315) | `` clickhouse: add patch for CVE-2024-6873 ``                                    |
| [`850096f4`](https://github.com/NixOS/nixpkgs/commit/850096f4e1f5e330ccd2d830defba7db0e939b53) | `` rustdesk-flutter: Make build reproducible ``                                  |
| [`a3071b66`](https://github.com/NixOS/nixpkgs/commit/a3071b665934de4bf8d15ff2883d53457a63508b) | `` rustdesk-flutter: 1.2.7 -> 1.3.0 ``                                           |
| [`b3dbb7ef`](https://github.com/NixOS/nixpkgs/commit/b3dbb7ef6419ee69fb92ca258612201b5110711d) | `` element-desktop: 1.11.75 -> 1.11.76 ``                                        |
| [`1bb1e77a`](https://github.com/NixOS/nixpkgs/commit/1bb1e77ae210eb9b1c38745e25aedfa042e756ab) | `` amazon-ssm-agent: 3.3.484.0 -> 3.3.551.0 ``                                   |
| [`04f61e7f`](https://github.com/NixOS/nixpkgs/commit/04f61e7fd5f0ab32802b3e0ea7c3e06c7348edce) | `` vencord: 1.9.4 -> 1.9.5 ``                                                    |
| [`55e9196c`](https://github.com/NixOS/nixpkgs/commit/55e9196c06a644c92dd5cc05b7198bc99eb4b49e) | `` vencord: 1.9.3 -> 1.9.4 ``                                                    |
| [`7674d72f`](https://github.com/NixOS/nixpkgs/commit/7674d72f215208af5495dcdd1ed9e77ea24cedb9) | `` vencord: 1.9.0 -> 1.9.3 ``                                                    |
| [`d1063ff0`](https://github.com/NixOS/nixpkgs/commit/d1063ff0ecc3ca865d47a01f48c5ab3e47d5b2b7) | `` vencord: 1.8.9 -> 1.9.0 ``                                                    |
| [`676a2524`](https://github.com/NixOS/nixpkgs/commit/676a252460197ca5e360ad8edf222cf5bed0b858) | `` jellyfin: 10.9.7 -> 10.9.10 ``                                                |
| [`e12c5260`](https://github.com/NixOS/nixpkgs/commit/e12c5260f747729ae29f3352cebd45f56ece39eb) | `` jellyfin-web: 10.9.7 -> 10.9.10 ``                                            |
| [`a8f54fe6`](https://github.com/NixOS/nixpkgs/commit/a8f54fe6eaa4bb31a09a7fc8a2399085dc7498e2) | `` bup: move to pkgs/by-name and reformat ``                                     |
| [`3eff4070`](https://github.com/NixOS/nixpkgs/commit/3eff4070df6e1ed33fc12131b5267170f7ede9f1) | `` bup: 0.33.3 -> 0.33.4 ``                                                      |
| [`c2fb017d`](https://github.com/NixOS/nixpkgs/commit/c2fb017dd30349289b104278d34fe10a30d25f7d) | `` starship: add patch for CVE-2024-41815 ``                                     |
| [`ad8ebb15`](https://github.com/NixOS/nixpkgs/commit/ad8ebb15ad5952cd01df27601a2d8e57e2cad49b) | `` duckdb: add patch for CVE-2024-41672 ``                                       |
| [`965628fb`](https://github.com/NixOS/nixpkgs/commit/965628fb5250d19285fa90de2dabb1515ecaaacb) | `` openresty: 1.21.4.3 -> 1.21.4.4 ``                                            |
| [`9eb18e6d`](https://github.com/NixOS/nixpkgs/commit/9eb18e6db60cdb9df34bf72e440f8f8961d1ded0) | `` argocd: 2.11.5 -> 2.11.7 ``                                                   |
| [`78de3ca2`](https://github.com/NixOS/nixpkgs/commit/78de3ca2c29ab65c22b029dc982318251c38c027) | `` argocd: 2.11.4 -> 2.11.5 ``                                                   |
| [`69259862`](https://github.com/NixOS/nixpkgs/commit/692598621b05dac62f22f86c094085249a9011d3) | `` argocd: 2.11.3 -> 2.11.4 ``                                                   |
| [`865e2ec6`](https://github.com/NixOS/nixpkgs/commit/865e2ec619c5a5feed5c0b5a5dc7b03038ea5411) | `` nuclei: add patch for CVE-2024-40641 ``                                       |
| [`c59e18b2`](https://github.com/NixOS/nixpkgs/commit/c59e18b238b8890e48d11c5c426e277cb568c284) | `` olm: add more information to `knownVulnerabilities` ``                        |
| [`93248145`](https://github.com/NixOS/nixpkgs/commit/93248145f85f578088a3dfe0c9c73d7a970dd132) | `` traefik: 3.0.2 -> 3.0.4 ``                                                    |
| [`533dacda`](https://github.com/NixOS/nixpkgs/commit/533dacda7c1e1be6fe65c8d63253582930b0e49e) | `` pomerium: add patch for CVE-2024-39315 ``                                     |
| [`325ab35b`](https://github.com/NixOS/nixpkgs/commit/325ab35b1e237af3d7eba8cff470f265b55a90f9) | `` brave: 1.68.141 -> 1.69.153 ``                                                |
| [`d79014a6`](https://github.com/NixOS/nixpkgs/commit/d79014a6360b4daccd7ff0e5ce448a5017004ac1) | `` leo-editor: use pyqt6 ``                                                      |
| [`4d1bd10b`](https://github.com/NixOS/nixpkgs/commit/4d1bd10b9ac843a353e73833a10e25facb9b4faa) | `` polypane: 20.1.1 -> 20.1.2 ``                                                 |
| [`7927ea1c`](https://github.com/NixOS/nixpkgs/commit/7927ea1c808e458bb801560b7ebecfc29f22bb99) | `` polypane: 20.0.0 -> 20.1.1 ``                                                 |
| [`c46bedfb`](https://github.com/NixOS/nixpkgs/commit/c46bedfb91267e5165bb60145da8474dc82a7c5a) | `` polypane: 19.0.2 -> 20.0.0 ``                                                 |
| [`35241e85`](https://github.com/NixOS/nixpkgs/commit/35241e85487895d351f6b28f73be6be629ffa834) | `` polypane: 19.0.1 -> 19.0.2 ``                                                 |
| [`56e4b26a`](https://github.com/NixOS/nixpkgs/commit/56e4b26ab18e0ebd3f08b07accdc52b41b751534) | `` {cinny,fluffychat,jitsi-meet}: inherit vulnerabilities from olm ``            |
| [`6f63fbf8`](https://github.com/NixOS/nixpkgs/commit/6f63fbf85a1dd1e25cbd789eba4fd0d12ff2eb55) | `` olm: mark as vulnerable ``                                                    |
| [`6e0ed0b7`](https://github.com/NixOS/nixpkgs/commit/6e0ed0b7e82cab1ff0bdcf96f33227babd5e52fe) | `` gparted: fix GParted not running on Wayland ``                                |
| [`7617350e`](https://github.com/NixOS/nixpkgs/commit/7617350eb3740ec89ae6ef039a9360a4067e0d2b) | `` mozillavpn: 2.21.0 → 2.23.1 ``                                                |
| [`dcf3cef2`](https://github.com/NixOS/nixpkgs/commit/dcf3cef2e70103c804ec87c120e32c06d50a1ef7) | `` mozillavpn: Use finalAttrs ``                                                 |
| [`8852e3c0`](https://github.com/NixOS/nixpkgs/commit/8852e3c0f2df407465adecfc6fc85d1e40f30acf) | `` mozillavpn: Reformat with nixfmt-rfc-style ``                                 |
| [`d6ca95ab`](https://github.com/NixOS/nixpkgs/commit/d6ca95ab05cfef69e3f975768751cced40eff03c) | `` git-workspace: 1.4.0 -> 1.5.0 ``                                              |
| [`fee11ef9`](https://github.com/NixOS/nixpkgs/commit/fee11ef959adac33aa2bca8ccbb7dda918fce8f6) | `` nixos/fcgiwrap: fail eval with security assertion ``                          |
| [`486943af`](https://github.com/NixOS/nixpkgs/commit/486943af002650cfea2022270173759691816abf) | `` ipu6: Don't build out-of-tree driver for kernels that have it ``              |
| [`31cdff5b`](https://github.com/NixOS/nixpkgs/commit/31cdff5bafec3425fc1b81ad570f97bf4c10d53a) | `` nixos/cgit: use isolated fcgiwrap instance, add user/group options ``         |
| [`483dd7e3`](https://github.com/NixOS/nixpkgs/commit/483dd7e3c642d0b71f7dce536b4255f0669d028c) | `` nixos/zoneminder: use isolated fcgiwrap instance ``                           |
| [`6a8e1242`](https://github.com/NixOS/nixpkgs/commit/6a8e12421c0e3fa868f3e972b9093fc62788f642) | `` nixos/smokeping: use isolated fcgiwrap instance ``                            |
| [`0cb11434`](https://github.com/NixOS/nixpkgs/commit/0cb1143443bdadeef1cd62f90219c2db5d898e1e) | `` nixos/fcgiwrap: add deprecation notice and security warning ``                |
| [`aaa04571`](https://github.com/NixOS/nixpkgs/commit/aaa045714c53964418d667aa152196a82a65cc5a) | `` nixos/fcgiwrap-instances: backport isolated multi-instance module ``          |
| [`5ec89ef9`](https://github.com/NixOS/nixpkgs/commit/5ec89ef9a5bbaff0534b21fc99652e298c6137e9) | `` nss_latest: 3.102 -> 3.102.1 ``                                               |
| [`1fac62a8`](https://github.com/NixOS/nixpkgs/commit/1fac62a83323f63c925bf91cad76e9fe3d0ac2cb) | `` nixos/tsm-client: Fix multi-value dsm.sys options ``                          |
| [`55f08904`](https://github.com/NixOS/nixpkgs/commit/55f0890416832bff72dd4af4f1577ce37a579f2a) | `` prismlauncher: use `lib.cmakeFeature` ``                                      |
| [`23772814`](https://github.com/NixOS/nixpkgs/commit/237728141d6db064c6afe25e58de676e15b98c2c) | `` prismlauncher: improve assertions ``                                          |
| [`65085985`](https://github.com/NixOS/nixpkgs/commit/65085985c7a07721fe5fda0c52f71bc9b1526037) | `` prismlauncher: add updateScript ``                                            |
| [`4ac007ec`](https://github.com/NixOS/nixpkgs/commit/4ac007ece3835c174e63f2d19328848a696fc0e3) | `` prismlauncher: refactor ``                                                    |
| [`fc3e31da`](https://github.com/NixOS/nixpkgs/commit/fc3e31dabe8a8882741e4135f700fa800366bedc) | `` prismlauncher: 8.3 -> 8.4 ``                                                  |
| [`b52304d0`](https://github.com/NixOS/nixpkgs/commit/b52304d09d8cf31154a5c7838e88541b310d6e33) | `` prismlauncher: format with nixfmt ``                                          |
| [`15a1a81c`](https://github.com/NixOS/nixpkgs/commit/15a1a81cf7f6295d9def67b6a8d1b492f28ad0e7) | `` prismlauncher: migrate to by-name ``                                          |
| [`cccab73e`](https://github.com/NixOS/nixpkgs/commit/cccab73e1ba3632861b9a61eba98fedffcbfe086) | `` xivlauncher: 1.0.9 -> 1.1.0 ``                                                |