### PR TITLE
chore(flake/plasma-manager): `b82b9ba8` -> `1b9c8200`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725575977,
-        "narHash": "sha256-1e9zB0dMRwdAbhxVATlL25rExMDh4gZ/3AXdkpU8408=",
+        "lastModified": 1725727445,
+        "narHash": "sha256-f5TrY73wfL4kvRmEtZXpzgCuxVFlNqMUNY6QSX16IPA=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "b82b9ba85c156a5e7f865cc94ed2a4df20cbbf39",
+        "rev": "1b9c8200d6438c98c427536abbc5b6fd6a5250c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`1b9c8200`](https://github.com/nix-community/plasma-manager/commit/1b9c8200d6438c98c427536abbc5b6fd6a5250c8) | `` Fix powerdevil options being reset without `overrideConfig` (#349) `` |
| [`d909dcd1`](https://github.com/nix-community/plasma-manager/commit/d909dcd13d1c9bcc0765f2dbf8243e423eae9f4e) | `` Refactor tiling layout type (#354) ``                                 |
| [`88686928`](https://github.com/nix-community/plasma-manager/commit/88686928e43f6794e8c5f0bf52ac1272bfd46f9f) | `` Add plasmusic-toolbar v1.6.0 option (#351) ``                         |