### PR TITLE
chore(flake/nixpkgs-stable): `6f6c45b5` -> `68e7dce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725407940,
-        "narHash": "sha256-tiN5Rlg/jiY0tyky+soJZoRzLKbPyIdlQ77xVgREDNM=",
+        "lastModified": 1725693463,
+        "narHash": "sha256-ZPzhebbWBOr0zRWW10FfqfbJlan3G96/h3uqhiFqmwg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
+        "rev": "68e7dce0a6532e876980764167ad158174402c6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`06cd8760`](https://github.com/NixOS/nixpkgs/commit/06cd87608fa18203f36072d5b1c9b3d6dd8de43f) | `` apr: 1.7.4 -> 1.7.5 ``                                                                   |
| [`d7aa3208`](https://github.com/NixOS/nixpkgs/commit/d7aa3208b77b05f1f0ac7f5480badd8c736c4ee5) | `` olm: fix typo in `knownVulnerabilities` message ``                                       |
| [`00f57363`](https://github.com/NixOS/nixpkgs/commit/00f573632989c2cca4802351c9235d9466245aa9) | `` python312Packages.kaleido: Enable on Darwin ``                                           |
| [`eb092c95`](https://github.com/NixOS/nixpkgs/commit/eb092c95ca89f25d3f202ed93c1e974653fd90ec) | `` firefox-beta-unwrapped: 130.0b2 -> 131.0b2 ``                                            |
| [`4e416f32`](https://github.com/NixOS/nixpkgs/commit/4e416f320682e6775d418c2924793e0a476bd98d) | `` firefox-beta-bin-unwrapped: 130.0b2 -> 131.0b2 ``                                        |
| [`1de509b4`](https://github.com/NixOS/nixpkgs/commit/1de509b41e214302e87f24e5a36ef745338e0dff) | `` firefox-beta-bin-unwrapped: 130.0b2 -> 131.0b2 ``                                        |
| [`473cf9c6`](https://github.com/NixOS/nixpkgs/commit/473cf9c65c57d7819195fd70e76a2c1152db619d) | `` firefox-devedition-bin-unwrapped: 130.0b1 -> 131.0b2 ``                                  |
| [`0b33363c`](https://github.com/NixOS/nixpkgs/commit/0b33363c4a6c09a015eff9c8af194e1f0ecbb6b0) | `` firefox-devedition-unwrapped: 129.0b9 -> 130.0b2 ``                                      |
| [`c7ec46bc`](https://github.com/NixOS/nixpkgs/commit/c7ec46bc4ef31d25bd86adeb4f944c5d66aeb8c3) | `` firefox-beta-unwrapped: 129.0b9 -> 130.0b2 ``                                            |
| [`4453f1c5`](https://github.com/NixOS/nixpkgs/commit/4453f1c5dc86a124b5dca5556e52332ac6064329) | `` firefox-devedition-bin-unwrapped: 129.0b9 -> 130.0b2 ``                                  |
| [`109eb22e`](https://github.com/NixOS/nixpkgs/commit/109eb22e9d1760c63d576b252dde46da2e2bddea) | `` firefox-beta-bin-unwrapped: 129.0b9 -> 130.0b2 ``                                        |
| [`fbafc41b`](https://github.com/NixOS/nixpkgs/commit/fbafc41bf297b7ae171c47d68f083ba4b0ba36d1) | `` librewolf-unwrapped: 129.0.2-1 -> 130.0-1 ``                                             |
| [`74114fda`](https://github.com/NixOS/nixpkgs/commit/74114fda7301c4a75867b70b9bb8beec3d06ff57) | `` forgejo: 7.0.8 -> 7.0.9 ``                                                               |
| [`0d620761`](https://github.com/NixOS/nixpkgs/commit/0d62076169c86d4f34cdb709c6d6293efa6e3e9e) | `` zfs-unstable: 2.2.4-unstable-2024-07-15 -> 2.2.5 ``                                      |
| [`33cd2ebb`](https://github.com/NixOS/nixpkgs/commit/33cd2ebbc098f25b356a1f2c6007dcba6f36245f) | `` zfs_2_2: 2.2.4 -> 2.2.5 ``                                                               |
| [`dd8ab0b3`](https://github.com/NixOS/nixpkgs/commit/dd8ab0b38a734ddff72fade304909027dee4788f) | `` qq: 3.2.12-2024.8.19 -> 3.2.12-2024.9.2 ``                                               |
| [`d79fcf52`](https://github.com/NixOS/nixpkgs/commit/d79fcf52ee783afae27836526b4b0afa02113e30) | `` xfsprogs: update homepage ``                                                             |
| [`b5947443`](https://github.com/NixOS/nixpkgs/commit/b5947443fa9f743908c09a2c4bb1edda71353127) | `` changelog-d: 1.0 -> 1.0.1 ``                                                             |
| [`7ee48d9f`](https://github.com/NixOS/nixpkgs/commit/7ee48d9f5f6e77aa085ee8b4468f064aa71c842d) | `` mautrix-meta: fixed typo in description ``                                               |
| [`5b0018f4`](https://github.com/NixOS/nixpkgs/commit/5b0018f4ce62e41debbb32c9b6bef4eac3598a02) | `` mautrix-meta: add updateScript ``                                                        |
| [`3634ef48`](https://github.com/NixOS/nixpkgs/commit/3634ef4889ba8d93c81a95860fd101773947cc88) | `` mautrix-meta: add eyjhb as maintainer ``                                                 |
| [`c202a2ee`](https://github.com/NixOS/nixpkgs/commit/c202a2eed770e1ec7962f080e59772a25f14f862) | `` twitch-chat-downloader: update client_id ``                                              |
| [`0ef8e1b0`](https://github.com/NixOS/nixpkgs/commit/0ef8e1b0525e62008cc7b03342cd5640dd4edd8c) | `` [Backport release-24.05] release-cuda: build with config.cudaSupport ``                  |
| [`6161f0ce`](https://github.com/NixOS/nixpkgs/commit/6161f0ce070789785dd46dd56de4acee72cb8c8f) | `` zfs: move maintainer adamcstephens to 2.2 only ``                                        |
| [`2fcfb0b4`](https://github.com/NixOS/nixpkgs/commit/2fcfb0b451cc789317d3c10f45228a3f341372a6) | `` python312Packages.kaleido: mark as broken on darwin ``                                   |
| [`40918382`](https://github.com/NixOS/nixpkgs/commit/40918382dd994b2ece2ad042570031868221d155) | `` python312Packages.plotly: adopt ``                                                       |
| [`8275caf0`](https://github.com/NixOS/nixpkgs/commit/8275caf0b488e8bdfae595124e428ee9404f3b88) | `` haproxy: 2.9.7 -> 2.9.10 ``                                                              |
| [`8a56d27d`](https://github.com/NixOS/nixpkgs/commit/8a56d27d2a303b762418dafe5d651f62e32ebd8d) | `` python312Packages.kaleido: Add passthru.tests ``                                         |
| [`56c8ff99`](https://github.com/NixOS/nixpkgs/commit/56c8ff99ce383f2a2584c6d4388e985e91bc744a) | `` python312Packages.plotly: Add kaleido to dependencies ``                                 |
| [`ff6949ea`](https://github.com/NixOS/nixpkgs/commit/ff6949ead667444578cdbc161a1e92efa1b4721d) | `` python312Packages.kaleido: init at 0.2.1 ``                                              |
| [`c5778d4b`](https://github.com/NixOS/nixpkgs/commit/c5778d4bd1d484258d5adc1f64dff239d9a4bd86) | `` nomachine-client: 8.4.2 -> 8.13.1 ``                                                     |
| [`344edec9`](https://github.com/NixOS/nixpkgs/commit/344edec94e5f7993ddca1ca10657a39396a2a470) | `` consul: 1.18.3 -> 1.18.4 ``                                                              |
| [`139ce176`](https://github.com/NixOS/nixpkgs/commit/139ce176e0e5f4536d7f94099d964fcd523a4194) | `` mullvad-browser: 13.5.2 -> 13.5.3 ``                                                     |
| [`b50e545b`](https://github.com/NixOS/nixpkgs/commit/b50e545bfad98be3064052112ba2db120e3d05d0) | `` tor-browser: 13.5.2 -> 13.5.3 ``                                                         |
| [`8a35d434`](https://github.com/NixOS/nixpkgs/commit/8a35d43459e5dce81404494d041ecc0c23d0cdc7) | `` google-chrome: fix makeWrapper invocation ``                                             |
| [`940477d7`](https://github.com/NixOS/nixpkgs/commit/940477d7b9297d3cc4eff2db2ba641d0b2ab815e) | `` maintainers-list: remove loveisgrief ``                                                  |
| [`d546a171`](https://github.com/NixOS/nixpkgs/commit/d546a17135d8a1a2a8605a1a7b5ff69748ced04f) | `` linux_4_19: 4.19.320 -> 4.19.321 ``                                                      |
| [`1f7c5f75`](https://github.com/NixOS/nixpkgs/commit/1f7c5f7585782c0ac7bcde3b8e38c20ff3981556) | `` linux_5_4: 5.4.282 -> 5.4.283 ``                                                         |
| [`20c1792b`](https://github.com/NixOS/nixpkgs/commit/20c1792bad46b93fa9309e7e173607aa50e12445) | `` linux_5_10: 5.10.224 -> 5.10.225 ``                                                      |
| [`daaade77`](https://github.com/NixOS/nixpkgs/commit/daaade77a1201bf195f78b6ab469cc4ecadf63ea) | `` linux_5_15: 5.15.165 -> 5.15.166 ``                                                      |
| [`c2fea7ff`](https://github.com/NixOS/nixpkgs/commit/c2fea7ff973411e15cefd168bdd3b7e77752d67a) | `` linux_6_1: 6.1.107 -> 6.1.108 ``                                                         |
| [`2f8f722f`](https://github.com/NixOS/nixpkgs/commit/2f8f722fe14a5abc7e4eb042a08aa4e82c1f69ad) | `` linux_6_6: 6.6.48 -> 6.6.49 ``                                                           |
| [`e3099ffd`](https://github.com/NixOS/nixpkgs/commit/e3099ffd289121895c6fe878d582783d54ff2136) | `` linux_6_10: 6.10.7 -> 6.10.8 ``                                                          |
| [`5a9dbf9e`](https://github.com/NixOS/nixpkgs/commit/5a9dbf9ed384264ba077ef94892f49d005b3ca78) | `` simple-dlna-browser: remove loveisgrief from maintainers ``                              |
| [`6c0f65c7`](https://github.com/NixOS/nixpkgs/commit/6c0f65c7f6ec069f675122da644d89d726e537ec) | `` prometheus: 2.53.1 → 2.54.1 ``                                                           |
| [`352867e2`](https://github.com/NixOS/nixpkgs/commit/352867e2ed15f032da4d0ff8cc2dd59b0d14dae9) | `` google-chrome: disable update notification ``                                            |
| [`cf192e60`](https://github.com/NixOS/nixpkgs/commit/cf192e602a169ae170bf71dc460b156e8c98163a) | `` [Backport release-24.05] koboldcpp: 1.73.1 -> 1.74 (#339067) ``                          |
| [`6a173c7c`](https://github.com/NixOS/nixpkgs/commit/6a173c7c128a4c6a1b021862a16f1211d884be5e) | `` prow: unstable-2020-04-01 -> 0-unstable-2024-08-27 ``                                    |
| [`4d58adbc`](https://github.com/NixOS/nixpkgs/commit/4d58adbc14d156df4ec86593c14f350eea1a6114) | `` qrcp: migrate to by-name ``                                                              |
| [`f2336a4f`](https://github.com/NixOS/nixpkgs/commit/f2336a4f1b3666f6ad6b4d90471ec6409d49a89b) | `` qrcp: 0.11.2 → 0.11.3, fix cross compilation ``                                          |
| [`8e654cc6`](https://github.com/NixOS/nixpkgs/commit/8e654cc60db0fd0302d08c1bba887b47283b05e6) | `` viceroy: 0.11.0 -> 0.12.0 ``                                                             |
| [`3524bec2`](https://github.com/NixOS/nixpkgs/commit/3524bec24f6222f73f043fad26934bfddd565f12) | `` firefox-esr-115-unwrapped: 115.14.0esr -> 115.15.0esr ``                                 |
| [`bc6a7a38`](https://github.com/NixOS/nixpkgs/commit/bc6a7a385c40e0320623008b90fa07cd59b89f9e) | `` firefox-esr-128-unwrapped: 128.1.0esr -> 128.2.0esr ``                                   |
| [`c46bbc5e`](https://github.com/NixOS/nixpkgs/commit/c46bbc5eb10d978ff0e51af30d33ddfb7b398911) | `` firefox-unwrapped: 129.0.2 -> 130.0 ``                                                   |
| [`449791a8`](https://github.com/NixOS/nixpkgs/commit/449791a8266517f0256eae429366d1700dcf6f74) | `` qq: 3.2.12 -> 3.2.12-2024.8.19 ``                                                        |
| [`c38f0ac0`](https://github.com/NixOS/nixpkgs/commit/c38f0ac067bdcd4bdea6d86a65970e13925e3236) | `` qq: add update-date into version ``                                                      |
| [`edfb5e97`](https://github.com/NixOS/nixpkgs/commit/edfb5e977874268abdf26ea7288b3fa9022140e4) | `` ungoogled-chromium: 128.0.6613.113-1 -> 128.0.6613.119-1 ``                              |
| [`27e0a13e`](https://github.com/NixOS/nixpkgs/commit/27e0a13efe21cd93d573872c37b25e6491926708) | `` chromium,chromedriver: 128.0.6613.113 -> 128.0.6613.119 ``                               |
| [`11eb7b59`](https://github.com/NixOS/nixpkgs/commit/11eb7b5916d00bff88adc7cd87d545df7ebad365) | `` chromium: match release blog entry titles case-insensitive in `get-commit-message.py` `` |
| [`a95ba485`](https://github.com/NixOS/nixpkgs/commit/a95ba485747d24477a9b37466e0849f855ac8a67) | `` nextcloud*Packages: update apps ``                                                       |
| [`12e14130`](https://github.com/NixOS/nixpkgs/commit/12e141300293866fe487faaa4e331484fbe2d37e) | `` nextcloud29: 29.0.5 -> 29.0.6 ``                                                         |
| [`5379bd60`](https://github.com/NixOS/nixpkgs/commit/5379bd6026d95db357a525b8776b65ad9485cb12) | `` zulip: 5.11.0 → 5.11.1 ``                                                                |
| [`46369c24`](https://github.com/NixOS/nixpkgs/commit/46369c246b4081553a50cf396fd2c961ad44e04f) | `` amazon-ssm-agent: substitute --replace with --replace-fail ``                            |
| [`1915b786`](https://github.com/NixOS/nixpkgs/commit/1915b786ff44fdcd6d87f86b21038f1c728c607b) | `` amazon-ssm-agent: 3.3.551.0 -> 3.3.808.0 ``                                              |