### PR TITLE
chore(flake/home-manager): `8a175a89` -> `be47a2bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725831139,
-        "narHash": "sha256-9syY5nEehCswE8AMcjpUO4T0iX9nrNbzq69Kqcs92L0=",
+        "lastModified": 1725863684,
+        "narHash": "sha256-HmdTBpuCsw35Ii35JUKO6AE6nae+kJliQb0XGd4hoLE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a175a89137fe798b33c476d4dae17dba5fb3fd3",
+        "rev": "be47a2bdf278c57c2d05e747a13ed31cef54a037",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`be47a2bd`](https://github.com/nix-community/home-manager/commit/be47a2bdf278c57c2d05e747a13ed31cef54a037) | `` k9s: remove katexochen as maintainer ``  |
| [`77c94148`](https://github.com/nix-community/home-manager/commit/77c94148285563113246eaf9f8df5488e00c81d0) | `` k9s: allow defining custom theme file `` |