### PR TITLE
chore(flake/sops-nix): `b68757cd` -> `cede1a08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -705,11 +705,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1725765163,
-        "narHash": "sha256-rfd2c47iVSFI6bRYy5l8wRijRBaYDeU7dM8XCDUGqlA=",
+        "lastModified": 1725922448,
+        "narHash": "sha256-ruvh8tlEflRPifs5tlpa0gkttzq4UtgXkJQS7FusgFE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b68757cd2c3fa66d6ccaa0d046ce42a9324e0070",
+        "rev": "cede1a08039178ac12957733e97ab1006c6b6892",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                           |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`cede1a08`](https://github.com/Mic92/sops-nix/commit/cede1a08039178ac12957733e97ab1006c6b6892) | `` build(deps): bump golang.org/x/crypto from 0.26.0 to 0.27.0 (#618) ``          |
| [`5ca82084`](https://github.com/Mic92/sops-nix/commit/5ca8208431e9f1c51d4d1dd2f72859a50beaaa3b) | `` build(deps): bump golang.org/x/sys from 0.24.0 to 0.25.0 (#617) ``             |
| [`9517dcbe`](https://github.com/Mic92/sops-nix/commit/9517dcbedb3d96f7c357daeb1448e558e7561c02) | `` build(deps): bump DeterminateSystems/update-flake-lock from 23 to 24 (#616) `` |