### PR TITLE
chore(flake/nixpkgs-stable): `68e7dce0` -> `f4c846ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725693463,
-        "narHash": "sha256-ZPzhebbWBOr0zRWW10FfqfbJlan3G96/h3uqhiFqmwg=",
+        "lastModified": 1725826545,
+        "narHash": "sha256-L64N1rpLlXdc94H+F6scnrbuEu+utC03cDDVvvJGOME=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68e7dce0a6532e876980764167ad158174402c6f",
+        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`7411580f`](https://github.com/NixOS/nixpkgs/commit/7411580f1835069d4985f09aacd6b23bf439cb01) | `` [Backport release-24.05] outline: 0.78.0 -> 0.79.0 (#340143) ``     |
| [`63bad7f8`](https://github.com/NixOS/nixpkgs/commit/63bad7f8c293f3a13f4776344f6d67078530badf) | `` linux-rt_6_6: 6.6.48-rt40 -> 6.6.49-rt41 ``                         |
| [`0ec71567`](https://github.com/NixOS/nixpkgs/commit/0ec7156728e49ae13df82e7db18f6e8aaf4c1ed4) | `` linux-rt_6_1: 6.1.107-rt39 -> 6.1.108-rt40 ``                       |
| [`b8de2c33`](https://github.com/NixOS/nixpkgs/commit/b8de2c335b3ece23efb9ed2a4c1c8a91c145b37c) | `` linux-rt_5_10: 5.10.223-rt115 -> 5.10.224-rt116 ``                  |
| [`aeb4eb64`](https://github.com/NixOS/nixpkgs/commit/aeb4eb643c32ed151fedcbccf0fcee00d1961907) | `` linux_6_1: 6.1.108 -> 6.1.109 ``                                    |
| [`9b8b5fdb`](https://github.com/NixOS/nixpkgs/commit/9b8b5fdbf694d17acfd31541b33951cab3808fcb) | `` linux_6_6: 6.6.49 -> 6.6.50 ``                                      |
| [`fc87ac16`](https://github.com/NixOS/nixpkgs/commit/fc87ac1698b49c5c972b138bfc303904e23fd570) | `` linux_6_10: 6.10.8 -> 6.10.9 ``                                     |
| [`f37f3c87`](https://github.com/NixOS/nixpkgs/commit/f37f3c87f372efade5dbbfddc6c6635b15bd8c9d) | `` frr: add patch for CVE-2024-44070 ``                                |
| [`447ed3b8`](https://github.com/NixOS/nixpkgs/commit/447ed3b8ee175a6d75ae2b22cb9ffc9b48cea2f6) | `` woodpecker-server: 2.7.0 -> 2.7.1 ``                                |
| [`a7fc926a`](https://github.com/NixOS/nixpkgs/commit/a7fc926a84443316b669fee6ea784ed82479a2ea) | `` microsoft-edge: 128.0.2739.42 -> 128.0.2739.54 ``                   |
| [`2e0e08f0`](https://github.com/NixOS/nixpkgs/commit/2e0e08f06075243e66f13a71d6b86a44ef5cbf06) | `` linuxPackages.nvidia_x11_legacy535: init at 535.154.05 ``           |
| [`adfa4596`](https://github.com/NixOS/nixpkgs/commit/adfa4596f577e49e676104af936a06033126603c) | `` Discord updates ``                                                  |
| [`cc73a878`](https://github.com/NixOS/nixpkgs/commit/cc73a878bfb9f090fb53b9f571d7ec81dfb9f60d) | `` unifi7: mark insecure due to CVE-2024-42025 ``                      |
| [`14d0dfcf`](https://github.com/NixOS/nixpkgs/commit/14d0dfcf8d89ceb63f514dcc09e365bc47bc16b2) | `` unifi8: 8.3.32 -> 8.4.59 ``                                         |
| [`f89feec7`](https://github.com/NixOS/nixpkgs/commit/f89feec76d46d8022afaefb9a968400a4ecf627e) | `` unifi8: 8.2.93 -> 8.3.32 ``                                         |
| [`41ba1118`](https://github.com/NixOS/nixpkgs/commit/41ba1118199a0dfe7ee9f2436d82c1bd4ad49a65) | `` unifi8: 8.1.127 -> 8.2.93 ``                                        |
| [`c2a2bf70`](https://github.com/NixOS/nixpkgs/commit/c2a2bf70c1f4ee43d6f4da91878206a263797298) | `` flarum: disable automatic DB creation ``                            |
| [`0e592034`](https://github.com/NixOS/nixpkgs/commit/0e5920346973ed7ecb0bdd479aeafa0aca593d9c) | `` flarum: fix flarum directory permissions ``                         |
| [`8a55c731`](https://github.com/NixOS/nixpkgs/commit/8a55c7312e70099c3b8e74a0658eb51897dba421) | `` pantalaimon: fix startup ``                                         |
| [`cbc24987`](https://github.com/NixOS/nixpkgs/commit/cbc24987d6d5469e3841d19ea75238b859086503) | `` runc: 1.1.13 -> 1.1.14 ``                                           |
| [`37e636e3`](https://github.com/NixOS/nixpkgs/commit/37e636e3722b0a5174e78770826d393c0e2c0d8e) | `` runc: 1.1.12 -> 1.1.13 ``                                           |
| [`7476fcc7`](https://github.com/NixOS/nixpkgs/commit/7476fcc775ad86e5320061ea873aac47d6dceb98) | `` vivaldi: 6.8.3381.57 -> 6.9.3447.37 ``                              |
| [`bf24ba28`](https://github.com/NixOS/nixpkgs/commit/bf24ba2812a6a2961cdd77abb66edfd1530aed13) | `` mbedtls_2: 2.28.8 -> 2.28.9 ``                                      |
| [`eff8fa7c`](https://github.com/NixOS/nixpkgs/commit/eff8fa7c48553a54f5494a200aac8eb7dc0bc421) | `` mbedtls: 3.6.0 -> 3.6.1 ``                                          |
| [`1cd13d2e`](https://github.com/NixOS/nixpkgs/commit/1cd13d2e9daa9dcbe90eb7c975afbe330f00622d) | `` gallery-dl: 1.27.3 -> 1.27.4 ``                                     |
| [`ac0eefa5`](https://github.com/NixOS/nixpkgs/commit/ac0eefa547fac06cbf46c9f160067e68e8678fd1) | `` gallery-dl: 1.27.2 -> 1.27.3 ``                                     |
| [`6368f188`](https://github.com/NixOS/nixpkgs/commit/6368f18800160e999410bb20e98a6e7d5add6815) | `` gallery-dl: 1.27.1 -> 1.27.2 ``                                     |
| [`64d2e0b5`](https://github.com/NixOS/nixpkgs/commit/64d2e0b5358018d2ee17c07484bbde0cbfcac89f) | `` gallery-dl: 1.27.0 -> 1.27.1 ``                                     |
| [`1a8c1778`](https://github.com/NixOS/nixpkgs/commit/1a8c17782fd67dad8db7c05aaad3b1a9c6420f88) | `` gallery-dl: remove `meta = with lib;` ``                            |
| [`4b852074`](https://github.com/NixOS/nixpkgs/commit/4b8520740a883100f542def623ed0784166424a3) | `` gallery-dl: format with nixfmt ``                                   |
| [`348dd2b5`](https://github.com/NixOS/nixpkgs/commit/348dd2b57053adf6b1eec9f196ec62b2e8327df8) | `` gallery-dl: 1.26.9 -> 1.27.0 ``                                     |
| [`cbe192e6`](https://github.com/NixOS/nixpkgs/commit/cbe192e66d7ec8897b103f692b7d1c1d8e875185) | `` unison-ucm: 0.5.25 -> 0.5.26 ``                                     |
| [`f41f4d0a`](https://github.com/NixOS/nixpkgs/commit/f41f4d0a65b16a813d4c53069c1f478d7288913f) | `` raycast: 1.81.2 -> 1.82.0 ``                                        |
| [`add378b3`](https://github.com/NixOS/nixpkgs/commit/add378b3bc57772afb0f8fe663775c0d2bea3868) | `` python312Packages.django_5: 5.0.8 -> 5.0.9 ``                       |
| [`910e6224`](https://github.com/NixOS/nixpkgs/commit/910e62245708112b8715e27e8be94cfe11db3569) | `` vivaldi: 6.8.3381.53 -> 6.8.3381.57 ``                              |
| [`54c7352e`](https://github.com/NixOS/nixpkgs/commit/54c7352e1f94423dc5cc699808e5893b829d150e) | `` python313FreeThreading: fix build ``                                |
| [`4daef604`](https://github.com/NixOS/nixpkgs/commit/4daef60456ed11148e8c5f49102bf38a5e7f9031) | `` openimageio: add patch for CVE-2024-40630 ``                        |
| [`939643bb`](https://github.com/NixOS/nixpkgs/commit/939643bb33d4b2ed44a8fc824c1d6e8ad29c4492) | `` docs: fix Nvidia casing to be consistent across different places `` |
| [`36ff3104`](https://github.com/NixOS/nixpkgs/commit/36ff3104c9a15564fb0632f6ddbf7a3c8f231762) | `` vivaldi: 6.8.3381.48 -> 6.8.3381.53 ``                              |
| [`95f2a43b`](https://github.com/NixOS/nixpkgs/commit/95f2a43bb8fd666c5e87b579ff7b7d50b410afd7) | `` vivaldi: 6.8.3381.46 -> 6.8.3381.48 ``                              |
| [`091a7cf2`](https://github.com/NixOS/nixpkgs/commit/091a7cf2550a3c44dd2eaa4bfa0fe81515849e49) | `` gitleaks: 8.18.2 -> 8.18.3 ``                                       |