### PR TITLE
chore(flake/home-manager): `10541f19` -> `e5fa72ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725893417,
-        "narHash": "sha256-fj2LxTZAncL/s5NrtXe1nLfO0XDvRixtCu3kmV9jDPw=",
+        "lastModified": 1725948275,
+        "narHash": "sha256-4QOPemDQ9VRLQaAdWuvdDBhh+lEUOAnSMHhdr4nS1mk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10541f19c584fe9633c921903d8c095d5411e041",
+        "rev": "e5fa72bad0c6f533e8d558182529ee2acc9454fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`e5fa72ba`](https://github.com/nix-community/home-manager/commit/e5fa72bad0c6f533e8d558182529ee2acc9454fe) | `` Translate using Weblate (Romanian) `` |