### PR TITLE
chore(flake/nixpkgs-stable): `f4c846ae` -> `44a71ff3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725826545,
-        "narHash": "sha256-L64N1rpLlXdc94H+F6scnrbuEu+utC03cDDVvvJGOME=",
+        "lastModified": 1725930920,
+        "narHash": "sha256-RVhD9hnlTT2nJzPHlAqrWqCkA7T6CYrP41IoVRkciZM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
+        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`44a71ff3`](https://github.com/NixOS/nixpkgs/commit/44a71ff39c182edaf25a7ace5c9454e7cba2c658) | `` nixVersions.nix_2_24,git: mark vulnerable ``                             |
| [`05bb1c56`](https://github.com/NixOS/nixpkgs/commit/05bb1c568285a87dcfaf66839933c7fcf8ae921b) | `` meshcentral: 1.1.27 -> 1.1.29 ``                                         |
| [`0a69f06f`](https://github.com/NixOS/nixpkgs/commit/0a69f06ffded28ca7079df6060d15064139db1ef) | `` gdouros: fix dn-works fonts issue ``                                     |
| [`5613934a`](https://github.com/NixOS/nixpkgs/commit/5613934ad7eb941b523ddc098008656930467cc0) | `` linux-firmware: 20240811 -> 20240909 ``                                  |
| [`0a00d66f`](https://github.com/NixOS/nixpkgs/commit/0a00d66fe69f2c38b80d6a4f3fff534a96884e26) | `` nixos-install: fail if we can't set up bootloader ``                     |
| [`8d41e916`](https://github.com/NixOS/nixpkgs/commit/8d41e9160780b18ff9bda6ce039cd829d8ee47ab) | `` monero-cli: fix build with miniupnpc ``                                  |
| [`c08ed769`](https://github.com/NixOS/nixpkgs/commit/c08ed769d168efd1272c535220de447222403d6b) | `` monero-{cli,gui}: require udev only on Linux ``                          |
| [`54d0213c`](https://github.com/NixOS/nixpkgs/commit/54d0213c00a0e94d62849710785543e2b7241be7) | `` monero-{cli,gui}: 0.18.3.3 -> 0.18.3.4 ``                                |
| [`c7916870`](https://github.com/NixOS/nixpkgs/commit/c7916870d9e66407505123a108b71cd09b94c863) | `` monero-cli: add patch for miniupnpc 2.2.8 ``                             |
| [`1852b475`](https://github.com/NixOS/nixpkgs/commit/1852b4755ff81bf926397ec99af068cfce83187a) | `` monero-cli: build with Ninja ``                                          |
| [`b9f8c12d`](https://github.com/NixOS/nixpkgs/commit/b9f8c12dac87634a44df48f3957a6cb2bb8abebf) | `` musescore: 4.3.0 -> 4.4.1 ``                                             |
| [`ba128c94`](https://github.com/NixOS/nixpkgs/commit/ba128c94d70e52fa2ba4cedad9fc49d4af5600b2) | `` exiftags: add CVE-2023-50671 & CVE-2024-42851 to knownVulnerabilities `` |
| [`7e888742`](https://github.com/NixOS/nixpkgs/commit/7e888742d200f38dfd3dbe2a2d320406fc567c8c) | `` python312Packages.quantities: prevent arbitrary code eval ``             |
| [`e3305673`](https://github.com/NixOS/nixpkgs/commit/e3305673ad9ce40b64a8374cbe2839d19b13ba5e) | `` python312Packages.quantities: modernize ``                               |
| [`6a31cde1`](https://github.com/NixOS/nixpkgs/commit/6a31cde1c209372461764b5bdc4704ca5a9550de) | `` podman: add vfkit to PATH for darwin ``                                  |
| [`a730b5bf`](https://github.com/NixOS/nixpkgs/commit/a730b5bf054867faa3e5de5fcff602c3518946e5) | `` vfkit: init at 0.5.1 ``                                                  |
| [`299c2dda`](https://github.com/NixOS/nixpkgs/commit/299c2dda2e254b1299b44030e00fa3d77a412d66) | `` python312Packages.notebook: 7.2.1 -> 7.2.2 ``                            |
| [`b92c4489`](https://github.com/NixOS/nixpkgs/commit/b92c4489c3f50831e759c850c693090fa2e37a78) | `` python311Packages.notebook: 7.2.0 -> 7.2.1 ``                            |
| [`1625808a`](https://github.com/NixOS/nixpkgs/commit/1625808a3db63978f69f833f1b88516a78b05aad) | `` wavebox: 10.127.10-2 -> 10.128.5-2 ``                                    |
| [`b857ccd1`](https://github.com/NixOS/nixpkgs/commit/b857ccd155790ec006596dbfc4df7fa463cf7642) | `` vencord: 1.9.9 -> 1.10.1 ``                                              |
| [`a2c60593`](https://github.com/NixOS/nixpkgs/commit/a2c60593cdfb2012c704f00178fc6c938c75a04f) | `` vencord: 1.9.8 -> 1.9.9 ``                                               |
| [`01c00210`](https://github.com/NixOS/nixpkgs/commit/01c0021095515ebfb362f5fda60d9cfaa4096f29) | `` vencord: 1.9.7 -> 1.9.8 ``                                               |
| [`fa96240d`](https://github.com/NixOS/nixpkgs/commit/fa96240d8f747ca914223715284e08db0d784a41) | `` vencord: fix update script ``                                            |
| [`07120dcc`](https://github.com/NixOS/nixpkgs/commit/07120dcc53d3c1e865aed26648af0fd24d2b133c) | `` vencord: sort inputs ``                                                  |
| [`3b66d78f`](https://github.com/NixOS/nixpkgs/commit/3b66d78f27d2ccb09c1a1e843763c069f715c273) | `` vencord: fix installPhase hooks ``                                       |
| [`14a12ed7`](https://github.com/NixOS/nixpkgs/commit/14a12ed7096c10d83c7f96652dae843ca689198b) | `` vencord: 1.9.5 -> 1.9.7 ``                                               |
| [`b643d24a`](https://github.com/NixOS/nixpkgs/commit/b643d24acb4bd46b7b2df3e6bf0aa5c6adf4d55b) | `` vencord: reformat using nixfmt ``                                        |
| [`e315ae4a`](https://github.com/NixOS/nixpkgs/commit/e315ae4ae90f6a59452266cf108b6b12da0712f2) | `` vencord: refactor to use pnpm.fetchDeps ``                               |
| [`cda035b8`](https://github.com/NixOS/nixpkgs/commit/cda035b84667fd6cce08ca95f67c1438b2d21033) | `` slurm: 23.11.9.1 -> 23.11.10.1 ``                                        |
| [`9743f1fc`](https://github.com/NixOS/nixpkgs/commit/9743f1fceae53d40d15628db8bd673ad1f435436) | `` notmuch-mailmover: 0.2.0 -> 0.3.0 ``                                     |
| [`895b9731`](https://github.com/NixOS/nixpkgs/commit/895b97314b13b96cbb87859c71a0f112fe65e558) | `` chatzone-desktop: init at 5.2.1 ``                                       |
| [`2e4f2295`](https://github.com/NixOS/nixpkgs/commit/2e4f22953b2b701b4d2897349f0cb4819c4bb510) | `` maintainers: add progrm_jarvis ``                                        |
| [`d2df32c0`](https://github.com/NixOS/nixpkgs/commit/d2df32c02fa7b3cc433690064e9eb5969356c1b7) | `` radio-cli: init at 2.3.1 ``                                              |