### PR TITLE
chore(flake/nixpkgs): `574d1eac` -> `1355a0cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1725983898,
+        "narHash": "sha256-4b3A9zPpxAxLnkF9MawJNHDtOOl6ruL0r6Og1TEDGCE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "1355a0cbfeac61d785b7183c0caaec1f97361b43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`1f38ed70`](https://github.com/NixOS/nixpkgs/commit/1f38ed70139f73474113a5ee04df2a94c99717b0) | `` nixos/tests: fix nixos-rebuild-specialisations test ``                                           |
| [`4aa2d69f`](https://github.com/NixOS/nixpkgs/commit/4aa2d69f55ac003d12a4c92f6fa7efb296a1086e) | `` ladybird: 0-unstable-2024-08-12 -> 0-unstable-2024-09-08 ``                                      |
| [`5a99fdf1`](https://github.com/NixOS/nixpkgs/commit/5a99fdf1ab833bd62edef737d52b915c8567db0f) | `` coursier: 2.1.10 -> 2.1.11 (#340930) ``                                                          |
| [`27e643cb`](https://github.com/NixOS/nixpkgs/commit/27e643cb3112568d1aee31735ace66183b1a7915) | `` lua-language-server: 3.10.5 -> 3.10.6 ``                                                         |
| [`871a39f6`](https://github.com/NixOS/nixpkgs/commit/871a39f6943d2477f43c85862f7404fd02cc8f8b) | `` gh-markdown-preview: 1.7.0 -> 1.8.0 ``                                                           |
| [`61be0d8e`](https://github.com/NixOS/nixpkgs/commit/61be0d8e27c71537bb543ee8ffb15863f7afae40) | `` sby: 0.44 -> 0.45 (#340966) ``                                                                   |
| [`6f5b0ef2`](https://github.com/NixOS/nixpkgs/commit/6f5b0ef20153916b202ad53450c10e2272d1d580) | `` radicle-node: 1.0.0-rc.17 → 1.0.0 ``                                                             |
| [`3a238a1f`](https://github.com/NixOS/nixpkgs/commit/3a238a1f8bb71f819f073b546bc1f0e756fbe300) | `` thrift-ls: change binary name to mimic upstream ``                                               |
| [`4111d41c`](https://github.com/NixOS/nixpkgs/commit/4111d41c0b2b86c5b935f2ba61cd1806a797a1a9) | `` maintainers: add hughmandalidis ``                                                               |
| [`7438ebd9`](https://github.com/NixOS/nixpkgs/commit/7438ebd9431243aa0b01502fae89c022e4facb0c) | `` viddy: 1.1.0 -> 1.1.2 (#340972) ``                                                               |
| [`3a33b6c3`](https://github.com/NixOS/nixpkgs/commit/3a33b6c3a846f3abca1e18d09563579b5081f6ac) | `` nixos/gancio: set default value for settings.baseurl ``                                          |
| [`432bfec0`](https://github.com/NixOS/nixpkgs/commit/432bfec0264157e5485768897a70b5193c2015a7) | `` nixos/gancio: use unix socket between nginx and gancio ``                                        |
| [`6bf23634`](https://github.com/NixOS/nixpkgs/commit/6bf23634b2860fab241f71b9de76186b20b5ac7f) | `` fireplace: init at 0-unstable-2020-02-02 ``                                                      |
| [`9e5a44bc`](https://github.com/NixOS/nixpkgs/commit/9e5a44bcfc9b513413f71b3162fa56d4229dbc45) | `` nixos/podman: set `preferLocalBuild` on trivial `runCommand`s (#340980) ``                       |
| [`511adb43`](https://github.com/NixOS/nixpkgs/commit/511adb43d188a5bd321def5bc8ddfe1d0e018e6f) | `` python312Packages.tencentcloud-sdk-python: 3.0.1227 -> 3.0.1228 ``                               |
| [`82f77adf`](https://github.com/NixOS/nixpkgs/commit/82f77adf9b59d38ef9feda98243dcc91f52dda8d) | `` uv: 0.4.7 -> 0.4.8 ``                                                                            |
| [`4637858c`](https://github.com/NixOS/nixpkgs/commit/4637858ca04f703326e3929fc356a354b441231d) | `` kdePackages: Plasma 6.1.4 -> 6.1.5 ``                                                            |
| [`a70eab34`](https://github.com/NixOS/nixpkgs/commit/a70eab343b1b5af03700d8e2312f3d89e1f85300) | `` livebook: 0.13.3 -> 0.14.0 ``                                                                    |
| [`77693ec7`](https://github.com/NixOS/nixpkgs/commit/77693ec7c3b5e61953cfb923beac98a1fecea626) | `` nitrokey-fido2-firmware: init at 2.4.1 ``                                                        |
| [`f5d40dac`](https://github.com/NixOS/nixpkgs/commit/f5d40dac128fb0f77b2d73ec70f3673b465e02c6) | `` nitrokey-pro-firmware: init at 0.15 ``                                                           |
| [`757fe30b`](https://github.com/NixOS/nixpkgs/commit/757fe30b6379b7fdc7b7de87fd4c8758f9979f47) | `` CONTRIBUTING.md: Update link to committers issue ``                                              |
| [`446599a6`](https://github.com/NixOS/nixpkgs/commit/446599a6f8c58755e08f346a8c6d20899ab33039) | `` yandex-music: 5.14.0 -> 5.15.0 ``                                                                |
| [`a719f91a`](https://github.com/NixOS/nixpkgs/commit/a719f91a85a2c303f00fa72e98b6acdf3ee56528) | `` nixos/teeworlds: use `lib.getExe` instead of hardcoded path ``                                   |
| [`e233e7d3`](https://github.com/NixOS/nixpkgs/commit/e233e7d385036ee811e911fcf599ae9eb4274ddf) | `` nixos/teeworlds: add option `environmentFile` for injecting secrets ``                           |
| [`8ad7b18b`](https://github.com/NixOS/nixpkgs/commit/8ad7b18b207dd811650b1e201e6054c502181b0b) | `` python312Packages.aioautomower: 2024.8.0 -> 2024.9.0 ``                                          |
| [`d8a0df68`](https://github.com/NixOS/nixpkgs/commit/d8a0df68b1eb0d01ad009379cba8d2d75fd0cee3) | `` python312Packages.aioairzone: 0.9.0 -> 0.9.1 ``                                                  |
| [`ba835626`](https://github.com/NixOS/nixpkgs/commit/ba83562611efa8133c459ed6cb3cc5c4a79866e7) | `` kics: 2.0.1 -> 2.1.2 ``                                                                          |
| [`e7d5c841`](https://github.com/NixOS/nixpkgs/commit/e7d5c84166f9814de252525091d701c30987a1bd) | `` when-cli: init at 0.4.0 ``                                                                       |
| [`81663d25`](https://github.com/NixOS/nixpkgs/commit/81663d25c2f989f23de5e88ee964cfdb1d8efa72) | `` python312Packages.yalexs: 8.6.3 -> 8.6.4 ``                                                      |
| [`11d2b276`](https://github.com/NixOS/nixpkgs/commit/11d2b2760bf73c20291c0e344798288734194d7c) | `` esphome: 2024.8.1 -> 2024.8.3 ``                                                                 |
| [`e521ac60`](https://github.com/NixOS/nixpkgs/commit/e521ac602864c397b6afee82fa553dacae563c55) | `` python312Packages.html2image: refactor ``                                                        |
| [`f280f797`](https://github.com/NixOS/nixpkgs/commit/f280f79715b09aa6a652aeaecd16ff97681cf0ba) | `` marwaita-mint: 20.3.1 -> 21 ``                                                                   |
| [`1166bb68`](https://github.com/NixOS/nixpkgs/commit/1166bb68ce1427d232df5bce79da63449f44b105) | `` klipper: 0.12.0-unstable-2024-08-14 -> 0.12.0-unstable-2024-09-01 ``                             |
| [`215204e8`](https://github.com/NixOS/nixpkgs/commit/215204e8d9c62c291894274fa47c8078314b8cfa) | `` klipperscreen: 0.3.2 -> 0.4.3 (#340939) ``                                                       |
| [`e13fbae7`](https://github.com/NixOS/nixpkgs/commit/e13fbae7cb266182c0710c8257b5624646ce14d4) | `` ubootOrangePi5Plus: expose ``                                                                    |
| [`cb714bfb`](https://github.com/NixOS/nixpkgs/commit/cb714bfbd4d1d791448e02177026d40f4c9eb266) | `` ubootOrangePi5Plus: init ``                                                                      |
| [`9bc2866b`](https://github.com/NixOS/nixpkgs/commit/9bc2866b4efc47d6a423ab9cab5ebdbd16ac745b) | `` homepage-dashboard: 0.9.6 -> 0.9.8 ``                                                            |
| [`1b449528`](https://github.com/NixOS/nixpkgs/commit/1b449528cc56cbfa2be8383a847da43c4f281e4e) | `` gitkraken: 10.2.0 -> 10.3.0 ``                                                                   |
| [`28108159`](https://github.com/NixOS/nixpkgs/commit/28108159e3ac34437a49c74f59eb225549f08b4c) | `` telegram-desktop: 5.5.1 -> 5.5.2 ``                                                              |
| [`17aec19b`](https://github.com/NixOS/nixpkgs/commit/17aec19b9a03a646da4341fcf2e0a3672970f663) | `` renovate: 38.62.0 -> 38.73.5 ``                                                                  |
| [`d7dc57b6`](https://github.com/NixOS/nixpkgs/commit/d7dc57b67310f06374e63d51860a6997a27ae4fd) | `` python312Packages.clarifai-grpc: 10.8.0 -> 10.8.4 ``                                             |
| [`323f66e1`](https://github.com/NixOS/nixpkgs/commit/323f66e1e7b1127d5db4d5d3f6ae527a124f8064) | `` cameractrls: 0.6.6 -> 0.6.7 ``                                                                   |
| [`d7423b75`](https://github.com/NixOS/nixpkgs/commit/d7423b75c9bc95adfa7547b13b482a0464f4a192) | `` clash-verge-rev: add meta for internal package ``                                                |
| [`4fad4c72`](https://github.com/NixOS/nixpkgs/commit/4fad4c72af67ee8701a4be41e248c41ab5af30a9) | `` srvc: drop ``                                                                                    |
| [`5f97b160`](https://github.com/NixOS/nixpkgs/commit/5f97b1604d9c3a0fe5186d5f9c71cb6404e2907e) | `` yara-x: 0.7.0 -> 0.8.0 ``                                                                        |
| [`baa6137a`](https://github.com/NixOS/nixpkgs/commit/baa6137ad637cbb245bd926a7998d65d48995bef) | `` python312Packages.ollama: 0.3.2 -> 0.3.3 ``                                                      |
| [`4ad5bc4c`](https://github.com/NixOS/nixpkgs/commit/4ad5bc4c012020ac88667c267cf43e25ad148296) | `` python312Packages.google-nest-sdm: 5.0.0 -> 5.0.1 ``                                             |
| [`6e235943`](https://github.com/NixOS/nixpkgs/commit/6e235943c873659ba42826e9c5e832d51fb75623) | `` python312Packages.weatherflow4py: 0.2.23 -> 0.3.3 ``                                             |
| [`5bf8cbcb`](https://github.com/NixOS/nixpkgs/commit/5bf8cbcbeb05725a1c04e1e4ff264a74c8e9aabb) | `` terraform-providers.utils: 1.23.0 -> 1.26.0 ``                                                   |
| [`25e41332`](https://github.com/NixOS/nixpkgs/commit/25e413323d309d730ed4af4b7de0132de8151262) | `` terraform-providers.gitlab: 17.1.0 -> 17.3.1 ``                                                  |
| [`2aaf174b`](https://github.com/NixOS/nixpkgs/commit/2aaf174b47542124abcb00c5ae78fb1339ca7ab7) | `` terraform-providers.dexidp: 0.5.0 -> 0.6.1 ``                                                    |
| [`aaf3f660`](https://github.com/NixOS/nixpkgs/commit/aaf3f660ec2bfd46f776adb588b49c50381eeab4) | `` terraform-providers.aws: 5.57.0 -> 5.66.0 ``                                                     |
| [`eaace95a`](https://github.com/NixOS/nixpkgs/commit/eaace95af23a43513debc1fe48fa8acd43980884) | `` terraform-providers.acme: 2.24.2 -> 2.26.0 ``                                                    |
| [`029b6c5e`](https://github.com/NixOS/nixpkgs/commit/029b6c5e5f31b0364b4868b6718d185a6a717b8f) | `` terraform-providers.cloudamqp: 1.29.4 -> 1.32.0 ``                                               |
| [`6d862016`](https://github.com/NixOS/nixpkgs/commit/6d86201665faf1e034d4ea1f25b560270849008c) | `` terraform-providers.checkly: 1.8.0 -> 1.8.2 ``                                                   |
| [`ad3a59c0`](https://github.com/NixOS/nixpkgs/commit/ad3a59c0b4194b28fcec3aed1b589285c047893a) | `` terraform-providers.buildkite: 1.10.1 -> 1.10.2 ``                                               |
| [`2c37d614`](https://github.com/NixOS/nixpkgs/commit/2c37d614841cb04348f2d999f650bfb62dc5e303) | `` terraform-providers.bitwarden: 0.8.0 -> 0.8.1 ``                                                 |
| [`bf09deff`](https://github.com/NixOS/nixpkgs/commit/bf09deff5f4c0fd47c581482d85ad89f98d9327a) | `` terraform-providers.bigip: 1.22.2 -> 1.22.3 ``                                                   |
| [`b474c679`](https://github.com/NixOS/nixpkgs/commit/b474c679732688e1eaea7a98b3128459a45790cb) | `` terraform-providers.baiducloud: 1.21.8 -> 1.21.9 ``                                              |
| [`43db517d`](https://github.com/NixOS/nixpkgs/commit/43db517dfe44d32f30314326817be63dcd252e95) | `` terraform-providers.azurerm: 3.111.0 -> 4.1.0 ``                                                 |
| [`16826a60`](https://github.com/NixOS/nixpkgs/commit/16826a60946a3c4b8af5ab573f6f8a0c17b95786) | `` terraform-providers.aviatrix: 3.1.4 -> 3.1.5 ``                                                  |
| [`17106a96`](https://github.com/NixOS/nixpkgs/commit/17106a965dcd8fde8e740abe266f922d8a4e7880) | `` terraform-providers.auth0: 1.3.0 -> 1.6.0 ``                                                     |
| [`47e347ec`](https://github.com/NixOS/nixpkgs/commit/47e347ec0562cae2e37de444103bf3a04f479b0c) | `` terraform-providers.yandex: 0.123.0 -> 0.128.0 ``                                                |
| [`9d05d572`](https://github.com/NixOS/nixpkgs/commit/9d05d572275f7284d62977a1e7c4d70f1ce36d27) | `` terraform-providers.vsphere: 2.8.2 -> 2.9.1 ``                                                   |
| [`98d072ec`](https://github.com/NixOS/nixpkgs/commit/98d072ec59c66e2efd8537bdd89be7cdba1db0bd) | `` terraform-providers.vault: 4.3.0 -> 4.4.0 ``                                                     |
| [`b54f3f96`](https://github.com/NixOS/nixpkgs/commit/b54f3f96c924ee94f5edb279c68cf87ecd24d3a1) | `` terraform-providers.turbot: 1.10.1 -> 1.11.1 ``                                                  |
| [`95327b7c`](https://github.com/NixOS/nixpkgs/commit/95327b7c1103ba597c1e47e886e6e9e3a7b47772) | `` terraform-providers.thunder: 1.4.1 -> 1.4.2 ``                                                   |
| [`d926de3c`](https://github.com/NixOS/nixpkgs/commit/d926de3cf8bba2a1a5d5eef3797da124afe50b7d) | `` terraform-providers.time: 0.11.2 -> 0.12.0 ``                                                    |
| [`e1268f65`](https://github.com/NixOS/nixpkgs/commit/e1268f65ddd98dad0b5166daead485fa68a07ce6) | `` terraform-providers.tencentcloud: 1.81.107 -> 1.81.120 ``                                        |
| [`baa89614`](https://github.com/NixOS/nixpkgs/commit/baa896143826867f4612f39b8b251acbb4d04450) | `` terraform-providers.tfe: 0.56.0 -> 0.58.1 ``                                                     |
| [`c8ac262d`](https://github.com/NixOS/nixpkgs/commit/c8ac262dd2a1262b91ee8d255ee0f406c50a09d6) | `` terraform-providers.temporalcloud: 0.0.9 -> 0.0.11 ``                                            |
| [`50aad7a5`](https://github.com/NixOS/nixpkgs/commit/50aad7a50548e3984d73a43ad03e7cbfa145998d) | `` terraform-providers.sumologic: 2.31.1 -> 2.31.3 ``                                               |
| [`931797a4`](https://github.com/NixOS/nixpkgs/commit/931797a4371b90761e9cf439802882de3908b46d) | `` terraform-providers.tailscale: 0.16.1 -> 0.16.2 ``                                               |
| [`7f37c505`](https://github.com/NixOS/nixpkgs/commit/7f37c505a115051665b0a892911f773cba14beaf) | `` terraform-providers.spotinst: 1.180.2 -> 1.190.0 ``                                              |
| [`002929a5`](https://github.com/NixOS/nixpkgs/commit/002929a52629bfc4760f755d2e5c3b064ace6131) | `` terraform-providers.spacelift: 1.14.0 -> 1.15.0 ``                                               |
| [`122a6656`](https://github.com/NixOS/nixpkgs/commit/122a6656a76f089b15bfbf9d39e8f49df4586ffb) | `` terraform-providers.snowflake: 0.92.0 -> 0.95.0 ``                                               |
| [`2e9221c1`](https://github.com/NixOS/nixpkgs/commit/2e9221c178fcba2a7705dd47d8082c306dc48470) | `` terraform-providers.sops: 1.0.0 -> 1.1.1 ``                                                      |
| [`f87bf47f`](https://github.com/NixOS/nixpkgs/commit/f87bf47f13df93276eff0a94b046c84fe4c0a3ec) | `` terraform-providers.signalfx: 9.1.5 -> 9.1.6 ``                                                  |
| [`e193613b`](https://github.com/NixOS/nixpkgs/commit/e193613b6be0f9e0e0180cc6e402b318f15baff7) | `` terraform-providers.selectel: 5.1.1 -> 5.3.0 ``                                                  |
| [`c2a38643`](https://github.com/NixOS/nixpkgs/commit/c2a386438bf31e15852a0e1b4e4efbc039881e65) | `` terraform-providers.scaleway: 2.41.3 -> 2.44.0 ``                                                |
| [`e8583f7c`](https://github.com/NixOS/nixpkgs/commit/e8583f7c692945115541f2968a99c033146aa83d) | `` terraform-providers.rancher2: 4.1.0 -> 5.0.0 ``                                                  |
| [`160172b2`](https://github.com/NixOS/nixpkgs/commit/160172b29de54c62c02eb501ed70da9b1a979094) | `` terraform-providers.project: 1.6.2 -> 1.7.2 ``                                                   |
| [`6c48acbe`](https://github.com/NixOS/nixpkgs/commit/6c48acbe5fbbf731af5da7a52b62ec26ebec41bd) | `` terraform-providers.postgresql: 1.22.0 -> 1.23.0 ``                                              |
| [`edbdbb03`](https://github.com/NixOS/nixpkgs/commit/edbdbb031f4613b73dd014dd156067bd39424272) | `` terraform-providers.pagerduty: 3.14.5 -> 3.15.6 ``                                               |
| [`601d7937`](https://github.com/NixOS/nixpkgs/commit/601d7937bd9ca8472150d03c579105a9c8f8c947) | `` terraform-providers.ovh: 0.45.0 -> 0.48.0 ``                                                     |
| [`1eddba35`](https://github.com/NixOS/nixpkgs/commit/1eddba357050f307e52132d7ca18856cc4de20fb) | `` terraform-providers.opsgenie: 0.6.35 -> 0.6.37 ``                                                |
| [`4d296f5b`](https://github.com/NixOS/nixpkgs/commit/4d296f5bf64c7a56780e8ef7a2209b64bd6d948e) | `` terraform-providers.opentelekomcloud: 1.36.12 -> 1.36.18 ``                                      |
| [`092bda98`](https://github.com/NixOS/nixpkgs/commit/092bda98a35d15881a64bb07f6d21784d404c917) | `` terraform-providers.openstack: 2.0.0 -> 2.1.0 ``                                                 |
| [`610636d8`](https://github.com/NixOS/nixpkgs/commit/610636d8366b49d3476fc59476e6eddd45ddfc30) | `` terraform-providers.oci: 6.1.0 -> 6.9.0 ``                                                       |
| [`bae76b71`](https://github.com/NixOS/nixpkgs/commit/bae76b713165297ebb7616b74e2edf88138085ca) | `` terraform-providers.onepassword: 2.1.0 -> 2.1.2 ``                                               |
| [`07293a76`](https://github.com/NixOS/nixpkgs/commit/07293a769d5853bea1fbe7dc9e9551fe7b2e0d0b) | `` terraform-providers.okta: 4.9.1 -> 4.10.0 ``                                                     |
| [`36a2b7da`](https://github.com/NixOS/nixpkgs/commit/36a2b7daecc5804227b32366f8597ed45ea35f92) | `` terraform-providers.nomad: 2.3.0 -> 2.3.1 ``                                                     |
| [`e62aa6ab`](https://github.com/NixOS/nixpkgs/commit/e62aa6ab30693f1625d84f18afabe97b167d756b) | `` terraform-providers.ns1: 2.3.1 -> 2.4.1 ``                                                       |
| [`eaa4c742`](https://github.com/NixOS/nixpkgs/commit/eaa4c7426eb5538aeec5e158edd51a12b87218f8) | `` terraform-providers.mongodbatlas: 1.17.3 -> 1.18.1 ``                                            |
| [`93a905a9`](https://github.com/NixOS/nixpkgs/commit/93a905a9d26541254666bf43870dad9a87af0e14) | `` terraform-providers.newrelic: 3.39.1 -> 3.45.0 ``                                                |
| [`377e7560`](https://github.com/NixOS/nixpkgs/commit/377e756024b01cfe1e74f24c0ac1670b21f6df2d) | `` terraform-providers.minio: 2.3.2 -> 2.5.0 ``                                                     |
| [`cb6250f5`](https://github.com/NixOS/nixpkgs/commit/cb6250f5bc834219c78cb4e01d96ed62a3b89f69) | `` terraform-providers.migadu: 2024.6.6 -> 2024.9.5 ``                                              |
| [`f4ccc6f0`](https://github.com/NixOS/nixpkgs/commit/f4ccc6f0f2417c5dcee7e270022486867b9b720e) | `` terraform-providers.linode: 2.23.1 -> 2.27.0 ``                                                  |
| [`2ab8acee`](https://github.com/NixOS/nixpkgs/commit/2ab8acee2731c953100c2179972af1e51d5f9152) | `` terraform-providers.lxd: 2.1.0 -> 2.3.0 ``                                                       |
| [`d4e577f8`](https://github.com/NixOS/nixpkgs/commit/d4e577f81c734ad0ac6083ae8451c44c579dd0ea) | `` terraform-providers.kubernetes: 2.31.0 -> 2.32.0 ``                                              |
| [`27a3bc07`](https://github.com/NixOS/nixpkgs/commit/27a3bc0781b5633c662ff9968c23445deb10f69a) | `` terraform-providers.launchdarkly: 2.19.0 -> 2.20.2 ``                                            |
| [`f41d1c47`](https://github.com/NixOS/nixpkgs/commit/f41d1c47db7a4713e307845b8e9160a9f333d14a) | `` terraform-providers.kafka: 0.7.1 -> 0.8.1 ``                                                     |
| [`7c404381`](https://github.com/NixOS/nixpkgs/commit/7c404381bab025ed1864af9c4b493b0cc662de63) | `` terraform-providers.ibm: 1.67.1 -> 1.69.0 ``                                                     |
| [`3e94cb7c`](https://github.com/NixOS/nixpkgs/commit/3e94cb7c3784a3abcdf242222414c1ac76083c5b) | `` terraform-providers.incus: 0.1.2 -> 0.1.4 ``                                                     |
| [`9cf5a0f3`](https://github.com/NixOS/nixpkgs/commit/9cf5a0f359df8bbccd3ddf2adca591666f65fd24) | `` terraform-providers.huaweicloud: 1.66.0 -> 1.68.1 ``                                             |
| [`33399476`](https://github.com/NixOS/nixpkgs/commit/333994761fe9d29b409e965ac9ab6aad5f10bb04) | `` terraform-providers.http: 3.4.3 -> 3.4.4 ``                                                      |
| [`ff375475`](https://github.com/NixOS/nixpkgs/commit/ff375475f631f974e35b37ad6d9b533155b0c8d0) | `` terraform-providers.helm: 2.14.0 -> 2.15.0 ``                                                    |
| [`0943570f`](https://github.com/NixOS/nixpkgs/commit/0943570f1087b1c55a0263a464e5f6931b1c512e) | `` terraform-providers.hcloud: 1.47.0 -> 1.48.1 ``                                                  |
| [`747110d9`](https://github.com/NixOS/nixpkgs/commit/747110d969369ce7c8e86f0ba859a0edc1e87771) | `` terraform-providers.harbor: 3.10.12 -> 3.10.15 ``                                                |
| [`d948b79c`](https://github.com/NixOS/nixpkgs/commit/d948b79cec0c3c95210d14ebba6e58e5f587dd4f) | `` terraform-providers.grafana: 3.2.1 -> 3.7.0 ``                                                   |
| [`b8051616`](https://github.com/NixOS/nixpkgs/commit/b8051616228f510f910ead07d28b04af15ac2862) | `` terraform-providers.gridscale: 1.25.0 -> 1.26.0 ``                                               |
| [`8966d1fe`](https://github.com/NixOS/nixpkgs/commit/8966d1fec6ea19c11fa607563cfbff1070d96e0e) | `` terraform-providers.google-beta: 5.36.0 -> 6.2.0 ``                                              |
| [`9508716b`](https://github.com/NixOS/nixpkgs/commit/9508716b02e85926ea9edd8a9d3d758027620462) | `` terraform-providers.google: 5.36.0 -> 6.2.0 ``                                                   |
| [`581aefbc`](https://github.com/NixOS/nixpkgs/commit/581aefbc62dabeec63b460aef32c65e097567752) | `` terraform-providers.github: 6.2.2 -> 6.2.3 ``                                                    |
| [`fc7afdd8`](https://github.com/NixOS/nixpkgs/commit/fc7afdd844b4f738e0a7d75826994d431c886c5a) | `` terraform-providers.fastly: 5.11.0 -> 5.13.0 ``                                                  |
| [`ec92744a`](https://github.com/NixOS/nixpkgs/commit/ec92744aff9df625825e650553ccf0832f7c7856) | `` terraform-providers.equinix: 2.0.1 -> 2.4.1 ``                                                   |
| [`9a5d30ef`](https://github.com/NixOS/nixpkgs/commit/9a5d30ef013c788b3166fdfe707c3989a97349e5) | `` terraform-providers.exoscale: 0.59.1 -> 0.59.2 ``                                                |
| [`72e01602`](https://github.com/NixOS/nixpkgs/commit/72e01602b1e1ee1ccc297fa20cbde2976353ab61) | `` terraform-providers.doppler: 1.8.0 -> 1.10.0 ``                                                  |
| [`d59bd9bd`](https://github.com/NixOS/nixpkgs/commit/d59bd9bdf0445353990aa975431d9769bbe0e1a0) | `` terraform-providers.dnsimple: 1.6.0 -> 1.7.0 ``                                                  |
| [`09bf0462`](https://github.com/NixOS/nixpkgs/commit/09bf0462143f0722fa5301527a3881a34ea2ade4) | `` terraform-providers.digitalocean: 2.39.2 -> 2.40.0 ``                                            |
| [`4bc1f3a3`](https://github.com/NixOS/nixpkgs/commit/4bc1f3a3139f6916cd5297e29738ceaa0767e940) | `` terraform-providers.datadog: 3.40.0 -> 3.44.0 ``                                                 |
| [`74a60f4e`](https://github.com/NixOS/nixpkgs/commit/74a60f4ef7707f6d462434e4295178c023b53c03) | `` terraform-providers.consul: 2.20.0 -> 2.21.0 ``                                                  |
| [`b97a34f5`](https://github.com/NixOS/nixpkgs/commit/b97a34f556d2b5f80eaf818ed404092067126804) | `` terraform-providers.constellix: 0.4.5 -> 0.4.6 ``                                                |
| [`c0bf8003`](https://github.com/NixOS/nixpkgs/commit/c0bf80038d8ad3fd0d917a52c4d325c58f011225) | `` terraform-providers.cloudflare: 4.36.0 -> 4.41.0 ``                                              |
| [`d70def76`](https://github.com/NixOS/nixpkgs/commit/d70def76252574602e3d495ddba2ae0558da0796) | `` terraform-providers.cloudscale: 4.3.0 -> 4.4.0 ``                                                |
| [`bb6cb708`](https://github.com/NixOS/nixpkgs/commit/bb6cb708992278b24db97c0ee1110b3ac5b3e69b) | `` terraform-providers.alicloud: 1.226.0 -> 1.230.0 ``                                              |
| [`de62478a`](https://github.com/NixOS/nixpkgs/commit/de62478a36dd32d121f82a9dbfcbeadc46235a8e) | `` terraform-providers.artifactory: 11.1.0 -> 11.9.1 ``                                             |
| [`8bb1d44e`](https://github.com/NixOS/nixpkgs/commit/8bb1d44ee597feeafae4a61caa2db9e9137abd2d) | `` terraform-providers.archive: 2.4.2 -> 2.6.0 ``                                                   |
| [`a05b61a4`](https://github.com/NixOS/nixpkgs/commit/a05b61a42a8e1d794455ed780b231a62d5d40cf9) | `` terraform-providers.akamai: 6.2.0 -> 6.4.0 ``                                                    |
| [`fc7f6c31`](https://github.com/NixOS/nixpkgs/commit/fc7f6c316538918b6ff8df99f243f045f28df2bb) | `` terraform-providers.aiven: 4.20.0 -> 4.24.0 ``                                                   |
| [`d67593d8`](https://github.com/NixOS/nixpkgs/commit/d67593d858e1f759246089cde74592773974578e) | `` terraform-providers: bump go to 1.23 ``                                                          |
| [`6b277227`](https://github.com/NixOS/nixpkgs/commit/6b2772275bea06491cf54c87b375a50b575d811e) | `` python312Packages.google-cloud-pubsub: 2.23.0 -> 2.23.1 ``                                       |
| [`c6409268`](https://github.com/NixOS/nixpkgs/commit/c6409268aaf79f9d6902bcf39b4ef2cba6a3969b) | `` python312Packages.html2image: 2.0.4.3 -> 2.0.5 ``                                                |
| [`065aa2c8`](https://github.com/NixOS/nixpkgs/commit/065aa2c8f71b5f115c95b0872585c0611e04774b) | `` python312Packages.elementpath: 4.4.0 -> 4.5.0 ``                                                 |
| [`728096d7`](https://github.com/NixOS/nixpkgs/commit/728096d788cfca7546330d5cef6e07f04371ee9e) | `` python312Packages.django-anymail: 11.1 -> 12.0 ``                                                |
| [`c751311f`](https://github.com/NixOS/nixpkgs/commit/c751311f1015e58c833a0fe9971068aa3448231b) | `` mpris-notifier: 0.1.7 -> 0.1.9 ``                                                                |
| [`4cec81a9`](https://github.com/NixOS/nixpkgs/commit/4cec81a9959ce612b653860dcca53101a36f328a) | `` Revert "modules/virtualisation: add shared options, merge various diskSize options" (#340894) `` |
| [`757e0a34`](https://github.com/NixOS/nixpkgs/commit/757e0a34b78e7f1c0b440ee1e7af2b388a52bd1c) | `` nixVersions.git: improve error message ``                                                        |
| [`4eee5997`](https://github.com/NixOS/nixpkgs/commit/4eee59973aedfc0a710b5d356ad600a8a5ae0864) | `` nixVersions.nix_2_24,git: mark vulnerable ``                                                     |
| [`303b35d9`](https://github.com/NixOS/nixpkgs/commit/303b35d97e72f1988ea7bac9711f7d561bf82a04) | `` golangci-lint: 1.60.3 -> 1.61.0 ``                                                               |
| [`98961952`](https://github.com/NixOS/nixpkgs/commit/989619524b8dffc5b0490aff6f611da3bc4956b5) | `` universal-ctags: add binary symlink for `universal-ctags` ``                                     |
| [`276a3f2a`](https://github.com/NixOS/nixpkgs/commit/276a3f2a71cad6f38118715c96da5729c912824b) | `` sploitscan: 0.10.5 -> 0.11.0 ``                                                                  |
| [`959c9e7b`](https://github.com/NixOS/nixpkgs/commit/959c9e7b6bd1b34ccb2af9cba36666a38e61f0aa) | `` dotenvx: 1.8.0 -> 1.14.0 ``                                                                      |