### PR TITLE
chore(flake/spicetify-nix): `28d73b74` -> `166bb6ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726028305,
-        "narHash": "sha256-pKiu7tnsanAj7U6dRWzgRTfonsb3Ty3DHIR3K8tfXLQ=",
+        "lastModified": 1726114643,
+        "narHash": "sha256-ncXNIXY4YzKDUHKJap3wNQTwflF0nLKGdSRCkQbcwVM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "28d73b741367fc51ea1b1a5a2252c8364d4134da",
+        "rev": "166bb6ee167695f17d80b4b6751a5be3facb919c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`166bb6ee`](https://github.com/Gerg-L/spicetify-nix/commit/166bb6ee167695f17d80b4b6751a5be3facb919c) | `` CI update 2024-09-12 `` |