### PR TITLE
chore(flake/home-manager): `da8406a6` -> `503af483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726142087,
-        "narHash": "sha256-uT4TRd3PgreUD5sJaNioVfMemdyWFLoPHqN4AFszGmw=",
+        "lastModified": 1726222338,
+        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da8406a6ff556b86dc368e96ca8bd81b2704a91a",
+        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`503af483`](https://github.com/nix-community/home-manager/commit/503af483e1b328691ea3a434d331995595fb2e3d) | `` eza: add support for fish abbreviations ``          |
| [`076c78ed`](https://github.com/nix-community/home-manager/commit/076c78edede4e7abc71af0b1610fb1fc1c0fac29) | `` fish: add `preferAbbrs` option ``                   |
| [`7923c691`](https://github.com/nix-community/home-manager/commit/7923c691527d2ee85fe028c6e780ac3bf8606f06) | `` neovide: add module ``                              |
| [`4c8647b1`](https://github.com/nix-community/home-manager/commit/4c8647b1ed35d0e1822c7997172786dfa18cd7da) | `` trayscale: add module ``                            |
| [`daaf0c2f`](https://github.com/nix-community/home-manager/commit/daaf0c2f8da6c7b5dc04dd62a3d98422f259551b) | `` kanshi: add support for output aliases ``           |
| [`cb3ab592`](https://github.com/nix-community/home-manager/commit/cb3ab5928cbe8ac3cfee7010ccad4c31dbc1fb5f) | `` helix: add example for use with evil-helix ``       |
| [`ea244c5a`](https://github.com/nix-community/home-manager/commit/ea244c5ae2205f0fced24dde2e555440303d63bc) | `` helix: remove outdated language-server comment ``   |
| [`433e6866`](https://github.com/nix-community/home-manager/commit/433e686675ba24176fe3383916a4bd1c9799c676) | `` autorandr: configModule.extraConfig ``              |
| [`ef506124`](https://github.com/nix-community/home-manager/commit/ef506124579ff6280a43a9596bb2a5049872bf8e) | `` gpg-agent: add launchd service agent and sockets `` |
| [`c82fc8cf`](https://github.com/nix-community/home-manager/commit/c82fc8cf3f75e667ad9dd3e5df721119b63723b3) | `` home-manager: use `hostname` from GNU inetutils ``  |
| [`2b1957a0`](https://github.com/nix-community/home-manager/commit/2b1957a0a3db7d63c1844abb84223655c30a7eb0) | `` home-manager: fix early exit due to FQDN error ``   |