### PR TITLE
chore(flake/nixpkgs-stable): `44a71ff3` -> `e65aa830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725930920,
-        "narHash": "sha256-RVhD9hnlTT2nJzPHlAqrWqCkA7T6CYrP41IoVRkciZM=",
+        "lastModified": 1726062281,
+        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
+        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`e65aa830`](https://github.com/NixOS/nixpkgs/commit/e65aa8301ba4f0ab8cb98f944c14aa9da07394f8) | `` [Backport release-24.05] vpsfree-client: 0.18.0 -> 0.19.0 (#340006) ``       |
| [`568fb2ba`](https://github.com/NixOS/nixpkgs/commit/568fb2baa5a6c5c9818c92576e8b312a45357c69) | `` ffcast: add awk to path ``                                                   |
| [`be7ee31f`](https://github.com/NixOS/nixpkgs/commit/be7ee31fc3037a557fe55390db063e73dfb6e009) | `` treewide: Fix remaining Android sdkVer and ndkVer references (#341106) ``    |
| [`afa916b1`](https://github.com/NixOS/nixpkgs/commit/afa916b1913d65ff92c919b9e059b2e5cc9a0f86) | `` microcode-intel: 20240813 -> 20240910 ``                                     |
| [`6c558485`](https://github.com/NixOS/nixpkgs/commit/6c558485869425e86a67d0c19a57193d160e7f87) | `` nixVersions.git: disable test on aarch64-linux ``                            |
| [`51a06e3d`](https://github.com/NixOS/nixpkgs/commit/51a06e3d79a83a009cf798ad85b0ba69dbed063a) | `` nixVersions.nix_2_24: 2.24.5 -> 2.24.6 ``                                    |
| [`8c187ba6`](https://github.com/NixOS/nixpkgs/commit/8c187ba62dc5c4f46f084947ad040a91a578c1bd) | `` nixVersions.git: 2.25.0pre20240807 -> 2.25.0pre20240910 ``                   |
| [`df9a6932`](https://github.com/NixOS/nixpkgs/commit/df9a693291926b3c6804e1d0fa05cef257a38853) | `` Revert "nixVersions.nix_2_24,git: mark vulnerable" ``                        |
| [`d1c50baf`](https://github.com/NixOS/nixpkgs/commit/d1c50baf0cc372e8e6d478d2fbd4d7b66ad9ab27) | `` Revert "nixVersions.git: improve error message" ``                           |
| [`ba610466`](https://github.com/NixOS/nixpkgs/commit/ba6104664022f914662df92a4efdc6057a8ed3b7) | `` zfs: Fix bash completions with 2.1 ``                                        |
| [`04c2feca`](https://github.com/NixOS/nixpkgs/commit/04c2feca6c17610164a62117986078e3198bd9de) | `` nixos/tests/zfs: Fix flake build ``                                          |
| [`056f1471`](https://github.com/NixOS/nixpkgs/commit/056f1471125c85bf5b4438a91375780f7f565adc) | `` zfs_2_2: 2.2.5 -> 2.2.6 ``                                                   |
| [`27b52adc`](https://github.com/NixOS/nixpkgs/commit/27b52adcb4c933be136b802af32765ca0dc4b75d) | `` zfs: dynamically determine latestCompatibleLinuxPackages ``                  |
| [`fe1ef01f`](https://github.com/NixOS/nixpkgs/commit/fe1ef01f1ea508836d1899add29e7e056202301c) | `` zfs_unstable: remove unused param ``                                         |
| [`d63965f1`](https://github.com/NixOS/nixpkgs/commit/d63965f14c04c439fba5a05f347152827001af09) | `` nixos/doc: move implementation notes for formats.libconfig to docs ``        |
| [`a77fc07e`](https://github.com/NixOS/nixpkgs/commit/a77fc07ef9ddd2df8591744105d30ceefb28bf73) | `` nixos/doc: add documentation for formats.libconfig ``                        |
| [`f326bccd`](https://github.com/NixOS/nixpkgs/commit/f326bccdbd455bde8930ab31185dc118bd5e64b5) | `` nixos/doc: move implementation notes for formats.hocon to docs ``            |
| [`e3d4cf9e`](https://github.com/NixOS/nixpkgs/commit/e3d4cf9eebeb872ff46f1de6993992defc837b76) | `` nixos/doc: add documentation for formats.hocon ``                            |
| [`196c3de2`](https://github.com/NixOS/nixpkgs/commit/196c3de2577f95e247cc7cef135cce42e0e5b92c) | `` lixVersions.lix_2_91: init ``                                                |
| [`94926353`](https://github.com/NixOS/nixpkgs/commit/94926353379412d9068cfa790e4dc6b4eebc7927) | `` lix: restore to approximately the state in master (pre 2.91) ``              |
| [`43d39bad`](https://github.com/NixOS/nixpkgs/commit/43d39bad3512a5e6c3acf35097e571615c6e6aa6) | `` nixosTests.misc: fix override ``                                             |
| [`49b3783b`](https://github.com/NixOS/nixpkgs/commit/49b3783b10bf3b7d95afa32169e32cc09dcdfd32) | `` openasar: 0-unstable-2024-06-30 -> 0-unstable-2024-09-06 ``                  |
| [`8d2662f1`](https://github.com/NixOS/nixpkgs/commit/8d2662f1166da2cdd417263cd6c6ae1b79ca3b00) | `` openasar: 0-unstable-2024-01-13 -> 0-unstable-2024-06-30 ``                  |
| [`edd84626`](https://github.com/NixOS/nixpkgs/commit/edd84626d14f5e99d7ae4436e5034929fc98c0bc) | `` hedgedoc: 1.9.9 -> 1.10.0 ``                                                 |
| [`c2526867`](https://github.com/NixOS/nixpkgs/commit/c2526867d82b5419b9de0391e18305c5bbf6585a) | `` nebula: 1.9.3 -> 1.9.4 ``                                                    |
| [`f3762903`](https://github.com/NixOS/nixpkgs/commit/f3762903d6ccdafac250ce9a1eb3ff351efa8005) | `` nixos/prometheus-exporters/pgbouncer: don't leak DB password into cmdline `` |
| [`1a658723`](https://github.com/NixOS/nixpkgs/commit/1a6587231b064ad33ed33db113035e37b32c6dcc) | `` nixos/prometheus-exporters: fix assertions declared in exporter modules ``   |
| [`f5dc68a7`](https://github.com/NixOS/nixpkgs/commit/f5dc68a766936ca616513c0f8cd94fff4ee09c16) | `` prometheus-pgbouncer-exporter: 0.8.0 -> 0.9.0 ``                             |
| [`dfc5b88a`](https://github.com/NixOS/nixpkgs/commit/dfc5b88a80f0af3bdec0ec966ebc0a40b89d0df6) | `` prometheus-dnsmasq-exporter: unstable-2024-05-06 -> 0.3.0 ``                 |
| [`979c9c12`](https://github.com/NixOS/nixpkgs/commit/979c9c1229a878536073737712c4984901b21aec) | `` flyctl: 0.2.124 -> 0.2.125 ``                                                |
| [`1c1881ff`](https://github.com/NixOS/nixpkgs/commit/1c1881ff94dfe9013829f729e33d29953eb572af) | `` gromacs: 2024.2 -> 2024.3 ``                                                 |
| [`5b2b2f7d`](https://github.com/NixOS/nixpkgs/commit/5b2b2f7d98d64505d62ff9fe99063dc845395e6b) | `` hyperv-daemons: fix fcopy build and nixfmt-rfc-style ``                      |
| [`0eca7472`](https://github.com/NixOS/nixpkgs/commit/0eca7472c5f1aa3ac8ce6c3695f57e378c5d3caa) | `` nix: add nix-team to CODEOWNERS ``                                           |
| [`5c8373ea`](https://github.com/NixOS/nixpkgs/commit/5c8373ea95c9e70c12dfc092f8d532ce68a95364) | `` nix: remove myself from "code ownership" and 2.3 maintenance ``              |
| [`0ddd6ce4`](https://github.com/NixOS/nixpkgs/commit/0ddd6ce4a909a0121079a714c53751424c5f905c) | `` nix: remove myself (ma27) from maintainer team ``                            |