### PR TITLE
chore(flake/home-manager): `6c1a461a` -> `e524c57b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726308872,
-        "narHash": "sha256-d4vwO5N4RsLnCY7k5tY9xbdYDWQsY3RDMeUoIa4ms2A=",
+        "lastModified": 1726357542,
+        "narHash": "sha256-p4OrJL2weh0TRtaeu1fmNYP6+TOp/W2qdaIJxxQay4c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c1a461a444e6ccb3f3e42bb627b510c3a722a57",
+        "rev": "e524c57b1fa55d6ca9d8354c6ce1e538d2a1f47f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`e524c57b`](https://github.com/nix-community/home-manager/commit/e524c57b1fa55d6ca9d8354c6ce1e538d2a1f47f) | `` mopidy: fix formatting `` |