### PR TITLE
chore(flake/nixpkgs-stable): `e65aa830` -> `8f7492cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726062281,
-        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
+        "lastModified": 1726320982,
+        "narHash": "sha256-RuVXUwcYwaUeks6h3OLrEmg14z9aFXdWppTWPMTwdQw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
+        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`14cb9779`](https://github.com/NixOS/nixpkgs/commit/14cb97791552c04e1852bea41859d6debc5898aa) | `` discord-development: 0.0.27 -> 0.0.28 ``                                               |
| [`a6b9c965`](https://github.com/NixOS/nixpkgs/commit/a6b9c9658652f7f1f4c219e07711581bd6a7e1b2) | `` gowall: 0.1.7 -> 0.1.8 ``                                                              |
| [`6ecc647b`](https://github.com/NixOS/nixpkgs/commit/6ecc647b4e0cf2e17f9d2a45b64e2a8df06ae516) | `` nixos/ups: set env vars in the global environment ``                                   |
| [`7ea9a39b`](https://github.com/NixOS/nixpkgs/commit/7ea9a39b4dd80701b68f21b562d55ea21cc28810) | `` nixos/ups: deduplicate environment variables ``                                        |
| [`419cfdd0`](https://github.com/NixOS/nixpkgs/commit/419cfdd0c58c2fca6bbf6f6147037d26e24ea7ae) | `` jwasm: fix install path ``                                                             |
| [`6b605ee3`](https://github.com/NixOS/nixpkgs/commit/6b605ee389e5dc28cdef4462afc283cd9ab3373d) | `` nextcloudPackages: update all ``                                                       |
| [`9ebd63ff`](https://github.com/NixOS/nixpkgs/commit/9ebd63ff032b6b2ec06ea65f37b56e2a35f43173) | `` nextcloud29: 29.0.6 -> 29.0.7 ``                                                       |
| [`a8a70f62`](https://github.com/NixOS/nixpkgs/commit/a8a70f6265ab88002a556bc218ac823c0dec879e) | `` nextcloud28: 28.0.9 -> 28.0.10 ``                                                      |
| [`c5380adf`](https://github.com/NixOS/nixpkgs/commit/c5380adf6b88b75d99568f1ef66f1fa77eb9e0d9) | `` microsoft-edge: 128.0.2739.54 -> 128.0.2739.67 ``                                      |
| [`37c274f9`](https://github.com/NixOS/nixpkgs/commit/37c274f994d39089dd43a651538fefec3c275918) | `` librewolf-unwrapped: 130.0-1 -> 130.0-3 ``                                             |
| [`b146bf52`](https://github.com/NixOS/nixpkgs/commit/b146bf525b3b60dd8880268caffed667f0c16128) | `` brave: 1.69.162 -> 1.69.168 ``                                                         |
| [`1dac89be`](https://github.com/NixOS/nixpkgs/commit/1dac89beed1b41df7a78812ca321294721c8e42d) | `` jellyfin: 10.9.10 -> 10.9.11 ``                                                        |
| [`c47d281d`](https://github.com/NixOS/nixpkgs/commit/c47d281d221d2a5e519a6422f4f4b3c6a53a6415) | `` jellyfin-web: 10.9.10 -> 10.9.11 ``                                                    |
| [`57954920`](https://github.com/NixOS/nixpkgs/commit/579549207d4485016cc2a8b5b0155ccad39629e3) | `` google-chrome: 128.0.6613.113 -> 128.0.6613.137 ``                                     |
| [`cd70dfe3`](https://github.com/NixOS/nixpkgs/commit/cd70dfe3f839de395ff91426481dd057a246a6e3) | `` linux_latest-libre: 19624 -> 19631 ``                                                  |
| [`9650804e`](https://github.com/NixOS/nixpkgs/commit/9650804e3b6c139cd9318cb0f2ee0781e1c256ee) | `` linux_4_19: 4.19.321 -> 4.19.322 ``                                                    |
| [`47bb8e42`](https://github.com/NixOS/nixpkgs/commit/47bb8e422b3ce070d5e1eeea643d8dd83bcdd276) | `` linux_5_4: 5.4.283 -> 5.4.284 ``                                                       |
| [`fd3c5e94`](https://github.com/NixOS/nixpkgs/commit/fd3c5e94e42249ae23a85765dcaf6af782601766) | `` linux_5_10: 5.10.225 -> 5.10.226 ``                                                    |
| [`76b313bb`](https://github.com/NixOS/nixpkgs/commit/76b313bbe431f2b9e61d9184b0e5b54c2f074fad) | `` linux_5_15: 5.15.166 -> 5.15.167 ``                                                    |
| [`3ca9095b`](https://github.com/NixOS/nixpkgs/commit/3ca9095b0922a1b3350d5ea625468c194520ccbb) | `` linux_6_1: 6.1.109 -> 6.1.110 ``                                                       |
| [`e5494e4d`](https://github.com/NixOS/nixpkgs/commit/e5494e4d7e69a431d292624573750f8751fbc719) | `` linux_6_6: 6.6.50 -> 6.6.51 ``                                                         |
| [`76cd2249`](https://github.com/NixOS/nixpkgs/commit/76cd2249fae6540e710619381cabe43336b46ee5) | `` linux_6_10: 6.10.9 -> 6.10.10 ``                                                       |
| [`79843e49`](https://github.com/NixOS/nixpkgs/commit/79843e49eb5b4d772fafe886cb0b428fe4ea9159) | `` linux_testing: 6.11-rc6 -> 6.11-rc7 ``                                                 |
| [`f58344f3`](https://github.com/NixOS/nixpkgs/commit/f58344f39f56e4ae3a13567650a8761a8db44c72) | `` ungoogled-chromium: 128.0.6613.119-1 -> 128.0.6613.137-1 ``                            |
| [`41e73a6b`](https://github.com/NixOS/nixpkgs/commit/41e73a6bc83c39952114a087216d988a07ff3427) | `` chromium,chromedriver: 128.0.6613.119 -> 128.0.6613.137 ``                             |
| [`3f949b33`](https://github.com/NixOS/nixpkgs/commit/3f949b33d68a2b1ee049084716ea2df941a578f8) | `` palemoon-bin: 33.3.0 -> 33.3.1 ``                                                      |
| [`6cab005a`](https://github.com/NixOS/nixpkgs/commit/6cab005aae3a917e217b97b781921ae8ef552c0b) | `` double-conversion: Allow static linking ``                                             |
| [`7f1f5d6f`](https://github.com/NixOS/nixpkgs/commit/7f1f5d6f82f27c399f53cd049627b42b7d11a8ce) | `` curl: apply patch for CVE-2024-8096 ``                                                 |
| [`f4172cc5`](https://github.com/NixOS/nixpkgs/commit/f4172cc5c40ffa127db1ec435949008c0d57398f) | `` fastly: 10.13.3 -> 10.14.0 ``                                                          |
| [`be66d371`](https://github.com/NixOS/nixpkgs/commit/be66d371321422043438096e87aa95efebbff632) | `` devenv: fix build on darwin ``                                                         |
| [`30739728`](https://github.com/NixOS/nixpkgs/commit/307397285b555615aae3633eca0a6f22689dc464) | `` devenv: 1.0.8 -> 1.1 ``                                                                |
| [`f87fedbb`](https://github.com/NixOS/nixpkgs/commit/f87fedbb0b1d304b60230c0933d86413ed8cb3e5) | `` devenv: rm test binaries ``                                                            |
| [`6e1195e4`](https://github.com/NixOS/nixpkgs/commit/6e1195e4244dcee87c5eedd66e4df6e2a494205d) | `` devenv: 1.0.7 -> 1.0.8 ``                                                              |
| [`bc9727e2`](https://github.com/NixOS/nixpkgs/commit/bc9727e2bbe36ad27246b739e3795bd83abaec1a) | `` devenv: 1.0.6 -> 1.0.7 ``                                                              |
| [`e048432a`](https://github.com/NixOS/nixpkgs/commit/e048432a775ac08d1d8d8cd6a3091cad49d98b4b) | `` devenv: 1.0.5 -> 1.0.6 ``                                                              |
| [`7c148375`](https://github.com/NixOS/nixpkgs/commit/7c148375c432ca6c92b0c5db3d6360c6bec1ca00) | `` waycheck: add pandapip1 to maintainers ``                                              |
| [`c663e4ba`](https://github.com/NixOS/nixpkgs/commit/c663e4bad1278a0004c6faa13645054b89fb7e17) | `` waycheck: add updateScript ``                                                          |
| [`57f3f9e9`](https://github.com/NixOS/nixpkgs/commit/57f3f9e9232c9e804bb2a3260a08c9e1f8fa64bf) | `` waycheck: nixfmt ``                                                                    |
| [`4fe286f2`](https://github.com/NixOS/nixpkgs/commit/4fe286f20846ceaea45b0c1099c5621b2fbdb7a4) | `` waycheck: 1.2.1 -> 1.3.1 ``                                                            |
| [`1444c737`](https://github.com/NixOS/nixpkgs/commit/1444c7379267c3bdd207ec625b4e7251fa7e747f) | `` netbird-ui: 0.28.9 -> 0.29.0 ``                                                        |
| [`d3ff616b`](https://github.com/NixOS/nixpkgs/commit/d3ff616b8c95af0fc2e774a47836106213a04b92) | `` asterisk: 20.9.2 -> 20.9.3 ``                                                          |
| [`0fbc35a0`](https://github.com/NixOS/nixpkgs/commit/0fbc35a0ad1b378a2afdb3c5aade798ae757cc90) | `` vivaldi: 6.9.3447.37 -> 6.9.3447.41 ``                                                 |
| [`f41a13fc`](https://github.com/NixOS/nixpkgs/commit/f41a13fc1b8e46ddb5be2ab4da501509bf8fb4e9) | `` nixos/syncthing: implement folder type (#308832) ``                                    |
| [`6f129cd6`](https://github.com/NixOS/nixpkgs/commit/6f129cd63f3fa2408c0e0356eb9a2b8616614de6) | `` thunderbirdPackages.thunderbird-115: 115.14.0 -> 115.15.0 ``                           |
| [`cb10bebd`](https://github.com/NixOS/nixpkgs/commit/cb10bebd311b49c92ff12301723a49a94c89258f) | `` brave: 1.69.153 -> 1.69.162 ``                                                         |
| [`e5a66890`](https://github.com/NixOS/nixpkgs/commit/e5a668905b0fa1dcd486c553a47dd01bfd37a907) | `` k3s_1_31: init 1.31.0+k3s1 ``                                                          |
| [`5f61a03f`](https://github.com/NixOS/nixpkgs/commit/5f61a03f7a19609e95b219d2514d9cd8bc4d0f0b) | `` k3s_1_30: 1.30.3+k3s1 -> 1.30.4+k3s1 ``                                                |
| [`16b41ff6`](https://github.com/NixOS/nixpkgs/commit/16b41ff637f5edc7116dbf54814965e08fabc1ae) | `` k3s_1_29: 1.29.7+k3s2 -> 1.29.8+k3s1 ``                                                |
| [`86cf2f8f`](https://github.com/NixOS/nixpkgs/commit/86cf2f8f5644ec2bddc8f292cc13deb740fe7812) | `` k3s_1_28: 1.28.12+k3s1 -> 1.28.13+k3s1 ``                                              |
| [`7e891c65`](https://github.com/NixOS/nixpkgs/commit/7e891c65c6cd85848a8c762204be2a0aa727f140) | `` k3s_1_27: remove ``                                                                    |
| [`303aac7b`](https://github.com/NixOS/nixpkgs/commit/303aac7b8301a44e9f61f03bd758b2115bf0e36c) | `` calibre: add patches for CVE-2024-6781, CVE-2024-6782, CVE-2024-7008, CVE-2024-7009 `` |
| [`806b01ad`](https://github.com/NixOS/nixpkgs/commit/806b01ad42c1e14c78ed32bea6305fcd54443528) | `` metal-cli: 0.23.1 -> 0.24.0 ``                                                         |