### PR TITLE
chore(flake/home-manager): `e524c57b` -> `a9c9cc6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726357542,
-        "narHash": "sha256-p4OrJL2weh0TRtaeu1fmNYP6+TOp/W2qdaIJxxQay4c=",
+        "lastModified": 1726440980,
+        "narHash": "sha256-ChhIrjtdu5d83W+YDRH+Ec5g1MmM0xk6hJnkz15Ot7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e524c57b1fa55d6ca9d8354c6ce1e538d2a1f47f",
+        "rev": "a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`a9c9cc6e`](https://github.com/nix-community/home-manager/commit/a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff) | `` sway: do not use `pkgs.sway` when `cfg.package = null` `` |
| [`76bf7798`](https://github.com/nix-community/home-manager/commit/76bf779881934ab476962b904a771378278290ad) | `` sway: un-extract single-use variable ``                   |
| [`25479e29`](https://github.com/nix-community/home-manager/commit/25479e29d1aefc72a3d031f2703530d6112818a3) | `` flake.lock: Update ``                                     |
| [`9c5f16d7`](https://github.com/nix-community/home-manager/commit/9c5f16d7034500ef11d4d6d787728878b4522874) | `` borgmatic: fix service permissions ``                     |