### PR TITLE
chore(flake/plasma-manager): `60becd0e` -> `5a0c70a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725914634,
-        "narHash": "sha256-U74hu15xSb6JNySMOwyJrsh4uk1DVa182bdHLeHdYMc=",
+        "lastModified": 1726509788,
+        "narHash": "sha256-PmCmO8NDKzwHrTp9Ox/rcLiCYivqIpZlnLk8wZRjv2I=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "60becd0e994e25b372c8d0500fc944396f6c1085",
+        "rev": "5a0c70a007837e2db01e0bb68971792e8653d32c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                               |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5a0c70a0`](https://github.com/nix-community/plasma-manager/commit/5a0c70a007837e2db01e0bb68971792e8653d32c) | `` Fix Window Rules Matching by Window Role (#364) `` |