### PR TITLE
chore(flake/nixpkgs-stable): `8f7492cc` -> `086b448a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726320982,
-        "narHash": "sha256-RuVXUwcYwaUeks6h3OLrEmg14z9aFXdWppTWPMTwdQw=",
+        "lastModified": 1726447378,
+        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
+        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`3d399406`](https://github.com/NixOS/nixpkgs/commit/3d3994069383fe984d79033d5689da7411ad04a3) | `` linux_6_11: init at 6.11 ``                                                  |
| [`19adb984`](https://github.com/NixOS/nixpkgs/commit/19adb9847edcc1f93d475d9761f4a30fef4bbcc3) | `` [Backport release-24.05] nixos/doc: update `Installing` section (#342125) `` |
| [`53ce4db9`](https://github.com/NixOS/nixpkgs/commit/53ce4db9de7f5ec9b5603c4d7e6f780e48417584) | `` strace: 6.10 -> 6.11 ``                                                      |
| [`33823bcc`](https://github.com/NixOS/nixpkgs/commit/33823bccd2a4790574bfb265ae3c3493e4b7275e) | `` envoy: 1.30.4 -> 1.30.5 ``                                                   |
| [`a27f3e7c`](https://github.com/NixOS/nixpkgs/commit/a27f3e7c8ab8fce38c495a9f9b7094483dbf9895) | `` sonarr: 4.0.4.1491 -> 4.0.9.2244 ``                                          |
| [`dab969f9`](https://github.com/NixOS/nixpkgs/commit/dab969f95b907d89604977a0273b7482191b6b66) | `` timetagger_cli: 23.8.3 -> 24.7.1 ``                                          |
| [`8c2d7530`](https://github.com/NixOS/nixpkgs/commit/8c2d7530d3d292e374471db439fd47e65622a9fe) | `` python312Packages.timetagger: 24.4.1 -> 24.07.1 ``                           |
| [`47f81b3d`](https://github.com/NixOS/nixpkgs/commit/47f81b3d5213968e6f2f0d6b59c911f3ecb21bda) | `` timetagger: 24.4.1 -> 24.07.1 ``                                             |
| [`474e47c1`](https://github.com/NixOS/nixpkgs/commit/474e47c1644d02b8e4b8ff7cf8d399f1daef50e5) | `` unifi8: 8.4.59 -> 8.4.62 ``                                                  |
| [`5321b8e6`](https://github.com/NixOS/nixpkgs/commit/5321b8e6bff758f8c560168633298c987d24ed26) | `` clamav: 1.3.1 -> 1.3.2 ``                                                    |
| [`3f7ddec0`](https://github.com/NixOS/nixpkgs/commit/3f7ddec0a282a86732122048045fa516228412b4) | `` gaugePlugins.makeGaugePlugin: fix darwin build ``                            |
| [`2bffedab`](https://github.com/NixOS/nixpkgs/commit/2bffedab891c1f60423531f71dc22777723b410d) | `` gaugePlugins.dotnet: add missing dependency on libgcc ``                     |
| [`a95d3696`](https://github.com/NixOS/nixpkgs/commit/a95d3696941dbc623f5f59d4e45d6bc93d408ee0) | `` makeGaugePlugin: add autoPatchelfHook ``                                     |