### PR TITLE
chore(flake/home-manager): `75781766` -> `1786e2af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726745512,
-        "narHash": "sha256-9xY9UEKC7gsA4sj5cZvZXk5jT/p2wGtkpp8hqE9yIRA=",
+        "lastModified": 1726785354,
+        "narHash": "sha256-SLorVhoorZwjM1aS04bBX4fufEXIfkMdAGkj9bu2QAQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7578176649a08abb73dfbd2755a5988766952b53",
+        "rev": "1786e2afdbc48e9038f7cff585069736e1d0ed44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`1786e2af`](https://github.com/nix-community/home-manager/commit/1786e2afdbc48e9038f7cff585069736e1d0ed44) | `` firefox: fix incorrect condition ``                           |
| [`b5e09b85`](https://github.com/nix-community/home-manager/commit/b5e09b85f22675923a61ef75e6e9188bd113a6e1) | `` firefox: only add Version = 2 on non-darwin ``                |
| [`1f7b8188`](https://github.com/nix-community/home-manager/commit/1f7b8188a9c9c5ba32f9a8351c55f42ecc22b77c) | `` zoxide: replace outdated flag in "options" example ``         |
| [`87c7d4df`](https://github.com/nix-community/home-manager/commit/87c7d4df161d0eafc0c8fe93a98ba5247a83d969) | `` firefox: fix policies availability ``                         |
| [`451606f4`](https://github.com/nix-community/home-manager/commit/451606f4a843752fc18cdcc764c0e7373ede3e96) | `` polybar: fix type of systemd Service.Environment ``           |
| [`480d589c`](https://github.com/nix-community/home-manager/commit/480d589cddf0057d7bac491bd9a08e5a083cf6cb) | `` opensnitch-client: fix type of systemd Service.Environment `` |
| [`7540dcc7`](https://github.com/nix-community/home-manager/commit/7540dcc7899193ddef035b19d91eecd57dacf30c) | `` opensnitch-ui: fix type of systemd Service.Environment ``     |
| [`dcc1a9e6`](https://github.com/nix-community/home-manager/commit/dcc1a9e6599905fe348e061b1471d82aa0a6275b) | `` nextcloud-client: fix type of systemd Service.Environment ``  |
| [`06c6695c`](https://github.com/nix-community/home-manager/commit/06c6695c8caa012bb0c7d794127ef2f94ef3137a) | `` grobi: fix type of systemd Service.Environment ``             |
| [`3670a035`](https://github.com/nix-community/home-manager/commit/3670a035868a8b074892bb17ee7743188f449d06) | `` hound: fix type of systemd Service.Environment ``             |
| [`cacf2d27`](https://github.com/nix-community/home-manager/commit/cacf2d27f6cd45ecc78a6a25404d4ed1ec8dd97d) | `` kbfs: fix type of systemd Service.Environment ``              |
| [`397750d2`](https://github.com/nix-community/home-manager/commit/397750d269041f071bad5abffdfed7329e7e0166) | `` xsettings: fix type of systemd Service.Environment ``         |
| [`336c792b`](https://github.com/nix-community/home-manager/commit/336c792b1936cd228de505c1c239e90422dfba74) | `` rsibreak: fix type of systemd Service.Environment ``          |
| [`80092fae`](https://github.com/nix-community/home-manager/commit/80092fae03d42f41952ae9227b193674da22596e) | `` mpd: fix type of systemd Service.Environment ``               |
| [`10fd27c2`](https://github.com/nix-community/home-manager/commit/10fd27c291479bb71e5debf40c28192bb14e978b) | `` kdeconnect: fix type of systemd Service.Environment ``        |
| [`ffc3a473`](https://github.com/nix-community/home-manager/commit/ffc3a473e62da754222a816ffe986b7fd0902da2) | `` xembed-sni-proxy: fix type of systemd Service.Environment ``  |
| [`1d8296c4`](https://github.com/nix-community/home-manager/commit/1d8296c46f3b688bcdf7f68ba7cf92fa6203c192) | `` flameshot: fix type of systemd Service.Environment ``         |
| [`b6204ff4`](https://github.com/nix-community/home-manager/commit/b6204ff489af6391eeb9feb43978fa3b81ac5d18) | `` xscreensaver: fix type of systemd Service.Environment ``      |