### PR TITLE
chore(flake/home-manager): `1786e2af` -> `4803bf55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726785354,
-        "narHash": "sha256-SLorVhoorZwjM1aS04bBX4fufEXIfkMdAGkj9bu2QAQ=",
+        "lastModified": 1726823634,
+        "narHash": "sha256-rU8Yy62KSLU8Q2J64F+50OJKORNdogxbXl2w4rFw13o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1786e2afdbc48e9038f7cff585069736e1d0ed44",
+        "rev": "4803bf558bdf20cb067aceb8830b7ad70113f4e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4803bf55`](https://github.com/nix-community/home-manager/commit/4803bf558bdf20cb067aceb8830b7ad70113f4e3) | `` swayidle: make -w optional ``                                  |
| [`8d7e352a`](https://github.com/nix-community/home-manager/commit/8d7e352a4b25ac2d88a881ffa3472680af916ddc) | `` poweralertd: Enable passing CLI args to the daemon ``          |
| [`6b191238`](https://github.com/nix-community/home-manager/commit/6b1912380e5577063401f58a2deb985fdc7cdc60) | `` ci: bump DeterminateSystems/update-flake-lock from 23 to 24 `` |
| [`f48b181f`](https://github.com/nix-community/home-manager/commit/f48b181f0161db6246a1bd1b05d70a7b3a87ab41) | `` ssh-agent: use POSIX conforming if condition ``                |
| [`ecaed80b`](https://github.com/nix-community/home-manager/commit/ecaed80b18e1d179d728d862c96d2fe43699226b) | `` kitty: remove IFD ``                                           |
| [`2cf3abce`](https://github.com/nix-community/home-manager/commit/2cf3abce034432cb357c0a6a670481819c55f564) | `` neovim: use `home.shellAliases` ``                             |