### PR TITLE
chore(flake/spicetify-nix): `49bb2ac8` -> `dae2f769`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726719408,
-        "narHash": "sha256-r/dXHHa6py/fKy087nGt4k3GoBjqFvpyZCsyRsXl0IA=",
+        "lastModified": 1726805771,
+        "narHash": "sha256-3zS5yxFRoRkzrJN7uih1ktaCrXlFqcav39Yh41UC0Vs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "49bb2ac8bdca209d235feabb9551dd09a5eb8ec9",
+        "rev": "dae2f7693f2e2e39007199778e5d7737c48d4c78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`dae2f769`](https://github.com/Gerg-L/spicetify-nix/commit/dae2f7693f2e2e39007199778e5d7737c48d4c78) | `` CI update 2024-09-20 `` |