### PR TITLE
chore(flake/stylix): `53bcceb4` -> `eccb9f2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -758,11 +758,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1726828291,
-        "narHash": "sha256-pGRPVVm7UXf+fx2NVpH6FFSWR9AynG6eoVlagaqH9i4=",
+        "lastModified": 1727093531,
+        "narHash": "sha256-hsb1bcUvpMecFHOP5F3LEyOnXiZ+5MikR92irJ8o7iE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "53bcceb4e46d0b3e8ae6434a7a6bcc3463092093",
+        "rev": "eccb9f2d63f4582b1c1ffe97d806156147aeee5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`eccb9f2d`](https://github.com/danth/stylix/commit/eccb9f2d63f4582b1c1ffe97d806156147aeee5f) | `` wezterm: support fancy_tab_bar (#564) `` |
| [`d56d759f`](https://github.com/danth/stylix/commit/d56d759fbadf2faf5258dfe1b7a94002c6206951) | `` i3status-rust: init (#548) ``            |