### PR TITLE
chore(flake/spicetify-nix): `b12df94e` -> `27aefaa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726978682,
-        "narHash": "sha256-YfTyq1sW7r1k0lCdhXDQbBskMwSKehlNMq8AgyFDkTo=",
+        "lastModified": 1727065001,
+        "narHash": "sha256-YG76K8qSYZ2el9HMGght15Bvo1xaxPYKTK9TWdJrWn0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b12df94e5574eaf9945bdb1238aa99a47b0ae5dc",
+        "rev": "27aefaa7fc56ea40202ad172b6e2f77f7377b2e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`27aefaa7`](https://github.com/Gerg-L/spicetify-nix/commit/27aefaa7fc56ea40202ad172b6e2f77f7377b2e7) | `` CI update 2024-09-23 `` |