### PR TITLE
chore(flake/nixpkgs-stable): `23cbb250` -> `babc25a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726969270,
-        "narHash": "sha256-8fnFlXBgM/uSvBlLWjZ0Z0sOdRBesyNdH0+esxqizGc=",
+        "lastModified": 1727129439,
+        "narHash": "sha256-nPyrcFm6FSk7CxzVW4x2hu62aLDghNcv9dX6DF3dXw8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23cbb250f3bf4f516a2d0bf03c51a30900848075",
+        "rev": "babc25a577c3310cce57c72d5bed70f4c3c3843a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`b6b948c3`](https://github.com/NixOS/nixpkgs/commit/b6b948c36f09eb46fac710895aaa35a05c3f6590) | `` garage: move from sha256 to hash ``                        |
| [`08d69ce0`](https://github.com/NixOS/nixpkgs/commit/08d69ce0b771c0cfa1ea86c235fa8aad5232442b) | `` snipe-it: 7.0.11 -> 7.0.12 ``                              |
| [`4a9e7971`](https://github.com/NixOS/nixpkgs/commit/4a9e7971aa381c1085149814f870473b664f8f4b) | `` snipe-it: 7.0.7 -> 7.0.11 ``                               |
| [`80e9e2b1`](https://github.com/NixOS/nixpkgs/commit/80e9e2b14677ed4b08120deb25ca3499fc7382e5) | `` snipe-it: 7.0.6 -> 7.0.7 ``                                |
| [`48d685b1`](https://github.com/NixOS/nixpkgs/commit/48d685b1115b7909f5caad0df87aa6cd0a24a07b) | `` snipe-it: 7.0.4 -> 7.0.6 ``                                |
| [`4ce3feb2`](https://github.com/NixOS/nixpkgs/commit/4ce3feb29940f37c07f3dd88de0885399b428153) | `` snipe-it: 6.4.2 -> 7.0.4 ``                                |
| [`bffd4c48`](https://github.com/NixOS/nixpkgs/commit/bffd4c48cae2ba50081808ffe96fb3aa8f6950b0) | `` colloid-gtk-theme: 2024-05-13 -> 2024-06-18 ``             |
| [`a5cb8915`](https://github.com/NixOS/nixpkgs/commit/a5cb891595cce446e0ed71d9b6318f5f014ed0a3) | `` google-chrome: 128.0.6613.138 -> 129.0.6668.59 (Darwin) `` |
| [`7982b54a`](https://github.com/NixOS/nixpkgs/commit/7982b54a507538a206e528f412a310b05b7164bc) | `` google-chrome: fix update script ``                        |
| [`b796bf9d`](https://github.com/NixOS/nixpkgs/commit/b796bf9d3f936573e43c91bd4353e9440436f421) | `` garage: 1.0.0 -> 1.0.1 ``                                  |
| [`56acf92e`](https://github.com/NixOS/nixpkgs/commit/56acf92e3d7fa46ea8fdf42827bf2fcbc247fecb) | `` wiki-js: 2.5.303 -> 2.5.304, fix CVE-2024-45298 ``         |
| [`6977bea3`](https://github.com/NixOS/nixpkgs/commit/6977bea3fa9f38aec52171e3beca86eaf7c1d40e) | `` matrix-synapse-unwrapped: 1.114.0 -> 1.115.0 ``            |
| [`b34eac72`](https://github.com/NixOS/nixpkgs/commit/b34eac728a84c3086926eeec91a997cfb367bf4a) | `` [release-24.05]: update nix-fallback-paths ``              |
| [`0ad5214f`](https://github.com/NixOS/nixpkgs/commit/0ad5214f14483dd815901b8e7ef9ca6b0d5e4375) | `` firefox-beta-unwrapped: 131.0b2 -> 131.0b9 ``              |
| [`2207ebbb`](https://github.com/NixOS/nixpkgs/commit/2207ebbb4139074700e51b08054cf17c2bfbfd06) | `` firefox-devedition-unwrapped: 131.0b2 -> 131.0b9 ``        |
| [`f6726fa2`](https://github.com/NixOS/nixpkgs/commit/f6726fa233e37f1a6cfddddc2ddaca96158097eb) | `` firefox-beta-bin-unwrapped: 131.0b2 -> 131.0b9 ``          |
| [`68b67dec`](https://github.com/NixOS/nixpkgs/commit/68b67decab56e6a3e8e04c13df3d6f3ab46f8e79) | `` firefox-devedition-bin-unwrapped: 131.0b2 -> 131.0b9 ``    |
| [`1217584b`](https://github.com/NixOS/nixpkgs/commit/1217584b501c89c840e0d9a139b9fd25a978469c) | `` vencord: 1.10.1 -> 1.10.2 ``                               |
| [`0e9509ed`](https://github.com/NixOS/nixpkgs/commit/0e9509eda0a4fdf9ec9ed16a40b1d93c30e6651c) | `` google-chrome: 128.0.6613.137 -> 129.0.6668.58 ``          |
| [`d6366768`](https://github.com/NixOS/nixpkgs/commit/d63667683134ae2eb32bca7ecfbeb2bcfdc91923) | `` nixVersions.git: 2.25.0pre20240910 -> 2.25.0pre20240920 `` |
| [`c592dd06`](https://github.com/NixOS/nixpkgs/commit/c592dd0687cbe42bd3a914062a6b5b2f7c6490dd) | `` nixVersions.nix_2_18: 2.18.5 -> 2.18.7 ``                  |
| [`e8d65bf4`](https://github.com/NixOS/nixpkgs/commit/e8d65bf48d05c1e339336727b89d87f0288f7739) | `` nixVersions.nix_2_24: 2.24.6 -> 2.24.7 ``                  |
| [`a6dd1e70`](https://github.com/NixOS/nixpkgs/commit/a6dd1e7035e7f17b26c73e259cfc849cfb404877) | `` fedifetcher: 7.1.4 -> 7.1.5 ``                             |
| [`9037d569`](https://github.com/NixOS/nixpkgs/commit/9037d56901bfaa5e39e82182d5666b3ca299363a) | `` fedifetcher: 7.1.1 -> 7.1.4 ``                             |
| [`9ab16fb2`](https://github.com/NixOS/nixpkgs/commit/9ab16fb240132174d94b314b2071618e0e464838) | `` fedifetcher: 7.0.5 -> 7.1.1 ``                             |
| [`f5e607c0`](https://github.com/NixOS/nixpkgs/commit/f5e607c0b45df2d5c67c8bebd94b76dda09dd4bf) | `` fedifetcher: adopt into c3d2 team ``                       |
| [`9abb177d`](https://github.com/NixOS/nixpkgs/commit/9abb177dc8414fe2d950d5d5659ae0d08a055e89) | `` fedifetcher: 7.0.4 -> 7.0.5 ``                             |
| [`44f8f653`](https://github.com/NixOS/nixpkgs/commit/44f8f65366454df1fde87bad1ad7a4df9b8c4e00) | `` thunderbird-bin-unwrapped: remove adwaita-icon-theme ``    |
| [`88121997`](https://github.com/NixOS/nixpkgs/commit/881219975ed89fccbafa6f667d3ec13a05ebcf04) | `` thunderbird-bin-unwrapped: 128.1.0esr -> 128.2.0esr ``     |
| [`6c5043e9`](https://github.com/NixOS/nixpkgs/commit/6c5043e984033827d104d0c589d41ed3460fa963) | `` thunderbird-bin: migrated to autoPatchelfHook ``           |
| [`fd539106`](https://github.com/NixOS/nixpkgs/commit/fd53910634a4ef49a050003d5092e6c2b8c85f19) | `` thunderbird-bin-unwrapped: 115.13.0 → 128.1.0esr ``        |
| [`5d99e595`](https://github.com/NixOS/nixpkgs/commit/5d99e595f14a0d277bb8d6de4067e47c2f9bca60) | `` amazon-ssm-agent: 3.3.808.0 -> 3.3.859.0 ``                |
| [`dac84a19`](https://github.com/NixOS/nixpkgs/commit/dac84a19e29370a72ae8792c07c56d723ac46b6c) | `` wordpress: 6.5.4 -> 6.5.5 ``                               |