### PR TITLE
chore(flake/spicetify-nix): `863ec9bd` -> `2f429398`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727237824,
-        "narHash": "sha256-T/34AmPn0Sxrnjzr+vpQVK81bt3vAS7ajUTSsOsuP1k=",
+        "lastModified": 1727343412,
+        "narHash": "sha256-Uoxb8Qr1bQp05SQIcAYCOfzImOJXIbWk4chTfxsd/us=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "863ec9bd1dcd383c4a22551ccb29234a73f094c8",
+        "rev": "2f429398aef267d98858ca98d2f2a38a8ee90fb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`2f429398`](https://github.com/Gerg-L/spicetify-nix/commit/2f429398aef267d98858ca98d2f2a38a8ee90fb3) | `` Bump actions/checkout from 4.1.7 to 4.2.0 (#231) `` |
| [`12818daa`](https://github.com/Gerg-L/spicetify-nix/commit/12818daad07217189b0f7a9203c0000040c8a6e4) | `` CI update 2024-09-26 ``                             |