### PR TITLE
chore(flake/nixpkgs): `9357f4f2` -> `30439d93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1726937504,
-        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
+        "lastModified": 1727122398,
+        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
+        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`087475f9`](https://github.com/NixOS/nixpkgs/commit/087475f93be76efc4013176fe8d845d7fe921f8a) | `` ocamlPackages.uucd: 15.1.0 → 16.0.0 ``                                    |
| [`21315e31`](https://github.com/NixOS/nixpkgs/commit/21315e31f86f0459ac0731868faeedc3a36ce30e) | `` CODEOWNERS: add myself to LLVM ``                                         |
| [`32cc0423`](https://github.com/NixOS/nixpkgs/commit/32cc04236834f5ba5c14b344f0106bea9cf65395) | `` mariadb: 10.5.26, 10.6.19, 10.11.9, 11.4.3 (#334878) ``                   |
| [`9f90e6b4`](https://github.com/NixOS/nixpkgs/commit/9f90e6b4d041a01ada4751b825765852f72c5264) | `` python312Packages.fastcore: 1.7.8 -> 1.7.9 ``                             |
| [`86959bc9`](https://github.com/NixOS/nixpkgs/commit/86959bc989bc3da9db00985df526c8dec7571c10) | `` vdrPlugins.softhddevice: 2.3.7 -> 2.3.8 ``                                |
| [`62c09a36`](https://github.com/NixOS/nixpkgs/commit/62c09a3647304d28907ac45c015ff5f8fb07ac94) | `` linux_5_4_hardened: mark as broken ``                                     |
| [`904a34e8`](https://github.com/NixOS/nixpkgs/commit/904a34e89ba1457cd55b6606a92c236ca6d90e6d) | `` linux/hardened/patches/6.9: remove ``                                     |
| [`57a558e4`](https://github.com/NixOS/nixpkgs/commit/57a558e46d0dc66981b9ab54261aa1216d6a5247) | `` linux/hardened/patches/6.8: remove ``                                     |
| [`f0e642ad`](https://github.com/NixOS/nixpkgs/commit/f0e642ad8bccc0c3c2754a3e1da4a4cffecbfb47) | `` linux/hardened/patches/4.19: remove ``                                    |
| [`6a510f85`](https://github.com/NixOS/nixpkgs/commit/6a510f85187e6370586a823ea924c060fe7d6278) | `` linux: drop EOLed kernels from kernels-org.json ``                        |
| [`e930509d`](https://github.com/NixOS/nixpkgs/commit/e930509d183abe4abc3cb55ee4f5c2284c1003e0) | `` linux/hardened/patches/6.6: 6.6.32-hardened1 -> v6.6.51-hardened1 ``      |
| [`1f403d3a`](https://github.com/NixOS/nixpkgs/commit/1f403d3a06fe27e83c21adfe5c68d08c31a136e3) | `` linux/hardened/patches/6.10: init at v6.10.10-hardened1 ``                |
| [`2794012a`](https://github.com/NixOS/nixpkgs/commit/2794012a3e1c8bbf8b58ef975213ebc2d3a2afe2) | `` linux/hardened/patches/6.1: 6.1.92-hardened1 -> v6.1.110-hardened1 ``     |
| [`6178bdf0`](https://github.com/NixOS/nixpkgs/commit/6178bdf0298f37f2ec35f0ede8f3f81e63868f82) | `` linux/hardened/patches/5.4: 5.4.277-hardened1 -> v5.4.284-hardened1 ``    |
| [`fec646af`](https://github.com/NixOS/nixpkgs/commit/fec646af8d166d7ed31a85c044921843a889bad0) | `` linux/hardened/patches/5.15: 5.15.160-hardened1 -> v5.15.167-hardened1 `` |
| [`ad3ec7bd`](https://github.com/NixOS/nixpkgs/commit/ad3ec7bd3d6f9eb1803f5ca0f6598260abb640de) | `` linux/hardened/patches/5.10: 5.10.218-hardened1 -> v5.10.226-hardened1 `` |
| [`60623de0`](https://github.com/NixOS/nixpkgs/commit/60623de0b351f669b2486ed0c6b32c0d826a234e) | `` linux/hardened: fix update script ``                                      |
| [`ee0928e3`](https://github.com/NixOS/nixpkgs/commit/ee0928e324521a42df1e68357db2aac337273f6e) | `` ssh-to-age: 1.1.8 -> 1.1.9 ``                                             |
| [`9ca6fb6d`](https://github.com/NixOS/nixpkgs/commit/9ca6fb6dcf6928359ebf6ae6ef983cb06918e862) | `` python312Packages.svg-py: 1.4.3 -> 1.5.0 ``                               |
| [`a0652e99`](https://github.com/NixOS/nixpkgs/commit/a0652e99b9bc6dc1a407760fd0f348d00b859972) | `` bitbucket-cli: init at 1.0.0 ``                                           |
| [`3db11314`](https://github.com/NixOS/nixpkgs/commit/3db11314908c41fcb4734a948a2a340c9c92ee68) | `` shattered-pixel-dungeon: 2.5.0 -> 2.5.2 ``                                |
| [`1ab344b7`](https://github.com/NixOS/nixpkgs/commit/1ab344b7e55ad3a5b3afcb563402ac4c516b6ea1) | `` imgpkg: init at 0.43.1 ``                                                 |
| [`9ebd4eeb`](https://github.com/NixOS/nixpkgs/commit/9ebd4eebab7fceb5e702ba32ee072adb39c4f4c1) | `` maintainers: add benchand ``                                              |
| [`1b32f1b5`](https://github.com/NixOS/nixpkgs/commit/1b32f1b57c4087b3794cc6bcf329e33c95aa2e9a) | `` dotnet: remove nuget-package-hook from runtime packages ``                |
| [`7cc2a137`](https://github.com/NixOS/nixpkgs/commit/7cc2a13773f31cd2b5328e76d529c8986c7dba52) | `` apostrophe: fix latex rendering by providing local mathjax ``             |
| [`32884474`](https://github.com/NixOS/nixpkgs/commit/32884474340ec657800ef0b4c189455850370a35) | `` jql: 7.1.13 -> 7.2.0 ``                                                   |
| [`7a319ad4`](https://github.com/NixOS/nixpkgs/commit/7a319ad43c3bea917c5671b13cd3e2beca4841d5) | `` lefthook: 1.7.15 -> 1.7.16 ``                                             |
| [`f6d6fcd7`](https://github.com/NixOS/nixpkgs/commit/f6d6fcd7dc2d5991be3fe9e77a198449dcb10387) | `` gpxsee: remove qt5compat from buildInputs ``                              |
| [`72e330b1`](https://github.com/NixOS/nixpkgs/commit/72e330b1c1a30ff9f2243d33fc4860736c20cc32) | `` python3Packages.ttfautohint-py: use correct description ``                |
| [`201d3582`](https://github.com/NixOS/nixpkgs/commit/201d35822e8ab85191ffc9d2c9097ae14d0fd50e) | `` nixos/nar-serve: remove `with lib;` (#343472) ``                          |
| [`6539d1b5`](https://github.com/NixOS/nixpkgs/commit/6539d1b561284a7c83315476b14ef1e893c66b19) | `` koboldcpp: 1.74 -> 1.75.2 ``                                              |
| [`b760aff9`](https://github.com/NixOS/nixpkgs/commit/b760aff9740377ddd88218ccb9ee80fab76c59e5) | `` rke2_testing: 1.31.0-rc1+rke2r1 -> 1.31.1-rc3+rke2r1 (#343540) ``         |
| [`0cbe501a`](https://github.com/NixOS/nixpkgs/commit/0cbe501a06afe2711c5eda812aa69fefe6113200) | `` grafana-loki: 3.1.1 -> 3.2.0 (#343173) ``                                 |
| [`b4162d91`](https://github.com/NixOS/nixpkgs/commit/b4162d91763c90b61fd7904a16abeb1ddad794ba) | `` cargo-chef: 0.1.67 -> 0.1.68 ``                                           |
| [`1b4f662e`](https://github.com/NixOS/nixpkgs/commit/1b4f662e9472dc336fd900abf358ca52007ab5f6) | `` cargo-shear: 1.1.2 -> 1.1.3 ``                                            |
| [`ce8ecb30`](https://github.com/NixOS/nixpkgs/commit/ce8ecb30b13ff3d68e56ab683f37ff611388b3f9) | `` crowdin-cli: 4.1.2 -> 4.2.0 ``                                            |
| [`82b9b282`](https://github.com/NixOS/nixpkgs/commit/82b9b2825227263aa271e68f10332fb469c5a5f3) | `` python312Packages.aiostreammagic: 2.3.1 -> 2.4.0 ``                       |
| [`1e6b54ae`](https://github.com/NixOS/nixpkgs/commit/1e6b54aeee114174b39b605b8c8dd7b08421ed6d) | `` arpa2common: format with nixfmt-rfc-style ``                              |
| [`d346ffcd`](https://github.com/NixOS/nixpkgs/commit/d346ffcd17a417e0da4c67697f14a83ffabed3db) | `` arpa2common: 2.2.18 -> 2.6.2 ``                                           |
| [`0fb7a292`](https://github.com/NixOS/nixpkgs/commit/0fb7a292e3567887410a5968b5ab2cc8ecaf9524) | `` minio: 2024-09-09T16-59-28Z -> 2024-09-13T20-26-02Z ``                    |
| [`f533b790`](https://github.com/NixOS/nixpkgs/commit/f533b790e7d3110258c39d113ee2b17193d8a4fd) | `` gqlgenc: 0.25.0 -> 0.25.1 ``                                              |
| [`28b2fdd2`](https://github.com/NixOS/nixpkgs/commit/28b2fdd261e8071e24f90e21361f8ba508ef3617) | `` mountpoint-s3: 1.9.0 -> 1.9.1 ``                                          |
| [`31ce1ce9`](https://github.com/NixOS/nixpkgs/commit/31ce1ce97f73495185c5cdeca6dcf1a4e3c7d725) | `` docker-compose: 2.29.3 -> 2.29.7 ``                                       |
| [`9601fce1`](https://github.com/NixOS/nixpkgs/commit/9601fce1d14317e3767453c3296516f95e67900f) | `` python312Packages.asteval: 1.0.3 -> 1.0.4 ``                              |
| [`28306a72`](https://github.com/NixOS/nixpkgs/commit/28306a729a1e99e7f5c41772a371e865917297e0) | `` snipe-it: 7.0.11 -> 7.0.12 ``                                             |
| [`52779a7b`](https://github.com/NixOS/nixpkgs/commit/52779a7b780c562d2c4483d5220de0398a593009) | `` firefly-iii-data-importer: 1.5.5 -> 1.5.6 ``                              |
| [`0699fe69`](https://github.com/NixOS/nixpkgs/commit/0699fe6957b4e74b6f5dd98e709efc4db0ad2c94) | `` pokeget-rs: 1.6.2 -> 1.6.3 ``                                             |
| [`13935f9f`](https://github.com/NixOS/nixpkgs/commit/13935f9ffd328a6399de738ef7ad2d044ef68cec) | `` moar: 1.27.0 -> 1.27.2 ``                                                 |
| [`93d8ee1b`](https://github.com/NixOS/nixpkgs/commit/93d8ee1b678d696130c55b6763514aa7c30b35c3) | `` credhub-cli: 2.9.37 -> 2.9.38 ``                                          |
| [`79d3272c`](https://github.com/NixOS/nixpkgs/commit/79d3272c536a6f9c9ce7c85383e917db1030be7e) | `` coqPackages.QuickChick: 2.0.2 → 2.0.4 ``                                  |
| [`c02bc173`](https://github.com/NixOS/nixpkgs/commit/c02bc17349cdde0cde05bedd30e631249203e6a0) | `` coqPackages.simple-io: 1.8.0 → 1.10.0 ``                                  |
| [`4513ea8c`](https://github.com/NixOS/nixpkgs/commit/4513ea8cb0dd96b4d1b79f01963a5f76c8da51d2) | `` ignite-cli: 28.5.2 -> 28.5.3 ``                                           |
| [`87c0458c`](https://github.com/NixOS/nixpkgs/commit/87c0458c4aabb6ff1c18162be0e16f5c42a2b3cb) | `` python312Packages.xmlschema: 3.4.1 -> 3.4.2 ``                            |
| [`c65e2f7d`](https://github.com/NixOS/nixpkgs/commit/c65e2f7d280cd3ba934bb899a4869f31d7426fa6) | `` easytier: init at 1.2.3 ``                                                |
| [`0c241853`](https://github.com/NixOS/nixpkgs/commit/0c24185366f374fcf805844857127c2867c32c56) | `` nixos: set system.stateVersion from the nixpkgs release, not version ``   |
| [`6e4d0242`](https://github.com/NixOS/nixpkgs/commit/6e4d0242b0e79797bfaacd79d962bdb36ef3194f) | `` mdbook-mermaid: 0.13.0 -> 0.14.0 ``                                       |
| [`d03e2a74`](https://github.com/NixOS/nixpkgs/commit/d03e2a74e3c68c31aa4b5fba31455aedf9f6c0fe) | `` backdown: 1.1.1 -> 1.1.2 ``                                               |
| [`40084740`](https://github.com/NixOS/nixpkgs/commit/40084740564879baf7b65db5297074a91769fc08) | `` thunderbird-unwrapped: 128.1.1esr -> 128.2.3esr ``                        |
| [`95f5cf75`](https://github.com/NixOS/nixpkgs/commit/95f5cf75d37fd6b437df35b6a48c5cd04053fbf0) | `` build-support/php: fix typo ``                                            |
| [`97c17485`](https://github.com/NixOS/nixpkgs/commit/97c17485d96fbb391f693f9d0029ca33f35c19c7) | `` flexget: 3.11.45 -> 3.11.46 ``                                            |
| [`0556c426`](https://github.com/NixOS/nixpkgs/commit/0556c426ff33a3c26bafcf68291a1a9f09e4090b) | `` nixos/pretix: fix database.host option type (#343917) ``                  |
| [`c52ee7dc`](https://github.com/NixOS/nixpkgs/commit/c52ee7dcd06117cfc8f8e964fdc31ad30a0bd2bc) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.55.0 -> 0.56.0 ``     |
| [`76d0095d`](https://github.com/NixOS/nixpkgs/commit/76d0095d769058f4c4f5ff422013ba856a21ac18) | `` vscode-extensions.apollographql.vscode-apollo: 2.2.0 -> 2.3.2 ``          |
| [`02b5f869`](https://github.com/NixOS/nixpkgs/commit/02b5f869e28b7f179f2fcecc12b1896ab978f090) | `` cargo-show-asm: 0.2.38 -> 0.2.39 ``                                       |
| [`33278de0`](https://github.com/NixOS/nixpkgs/commit/33278de087b75243bd6e7480bcd622a2c5279201) | `` python312Packages.numpyro: disable failing test on darwin ``              |
| [`5ca6aa40`](https://github.com/NixOS/nixpkgs/commit/5ca6aa4004d944387e7580060342d4954e1bfddf) | `` python312Packages.numpyro: switch to fetchFromGitHub ``                   |
| [`94d0d228`](https://github.com/NixOS/nixpkgs/commit/94d0d228173faff39670bc1157ddba8e56012a8d) | `` ocamlPackages.elpi: use release tarball (#343266) ``                      |
| [`55c48074`](https://github.com/NixOS/nixpkgs/commit/55c480745bb93b67792eeeb5669935e15c6999f3) | `` python3Packages.morecantile: disable one failing test for darwin ``       |
| [`de112a50`](https://github.com/NixOS/nixpkgs/commit/de112a504fd76ce0783ef4da54efb92a0970f57b) | `` python3Packages.morecantile: 5.3.0 -> 5.4.2 ``                            |
| [`07e6929c`](https://github.com/NixOS/nixpkgs/commit/07e6929c812d6df226b0f326178f15e93aba1a33) | `` build-support/php: fix environment variables for Composer ``              |
| [`3bcaabbb`](https://github.com/NixOS/nixpkgs/commit/3bcaabbb7119cb06f7f79770baf2e11ad293955c) | `` build-support/php: fix comments in multi-lines command ``                 |
| [`d533a821`](https://github.com/NixOS/nixpkgs/commit/d533a821bccde13307dadb97e2987a2447669b6f) | `` gpxsee: 13.24 -> 13.26 ``                                                 |
| [`5a44a67c`](https://github.com/NixOS/nixpkgs/commit/5a44a67c873775af1a37ad1edf3d9e9397e65568) | `` boilr: fix build ``                                                       |
| [`a0a0b4d6`](https://github.com/NixOS/nixpkgs/commit/a0a0b4d63bdc89990c7009dc6b0beb5ee36efe6b) | `` rustdesk-flutter: add missing libayatana-appindicator patch (#343742) ``  |
| [`be138083`](https://github.com/NixOS/nixpkgs/commit/be138083315257507575b68b3941bc6b70e5a832) | `` uwsm: 0.19.0 -> 0.19.1 ``                                                 |
| [`59d2f50a`](https://github.com/NixOS/nixpkgs/commit/59d2f50afc1d3f30560587dc1894137bdc51f445) | `` aws-sam-cli: update formatting ``                                         |
| [`15d09a0b`](https://github.com/NixOS/nixpkgs/commit/15d09a0b05dd7be4f9817c785bf4566e7bcbfe68) | `` aws-sam-cli: disable flaky test and add missing input ``                  |
| [`58923b79`](https://github.com/NixOS/nixpkgs/commit/58923b792c967ee1f738f2bdfbd346d03fa3f1f0) | `` minio-client: 2024-09-09T07-53-10Z -> 2024-09-16T17-43-14Z ``             |
| [`0010d951`](https://github.com/NixOS/nixpkgs/commit/0010d951740bc74e6ab4c2f8a26c87ea9f2dd786) | `` boilr: run nixfmt ``                                                      |
| [`92613243`](https://github.com/NixOS/nixpkgs/commit/926132437254bc44c56c9b2eee1d129876c537f7) | `` python312Packages.restfly: 1.4.7 -> 1.5.0 ``                              |
| [`3e98e7e2`](https://github.com/NixOS/nixpkgs/commit/3e98e7e2ae99592b2f3f147c10c9bc3648c61e4e) | `` python312Packages.slack-sdk: 3.33.0 -> 3.33.1 ``                          |
| [`51fe0368`](https://github.com/NixOS/nixpkgs/commit/51fe0368e9ab6cf7cf0a017c012896f27ada0ab6) | `` python312Packages.ufmt: 2.7.2 -> 2.7.3 ``                                 |
| [`c0d12c19`](https://github.com/NixOS/nixpkgs/commit/c0d12c19cb8aaef9c9a99a69995a919426472fcc) | `` python312Packages.publicsuffixlist: 1.0.2.20240918 -> 1.0.2.20240920 ``   |
| [`7198878c`](https://github.com/NixOS/nixpkgs/commit/7198878c8064fff05f8fe7132d0da470057b67f4) | `` ldeep: 1.0.65 -> 1.0.66 ``                                                |
| [`b0da153b`](https://github.com/NixOS/nixpkgs/commit/b0da153b6cf1d8dddf4a63d6ad0f353c78071dd2) | `` python312Packages.weheat: 2024.09.10 -> 2024.09.23 ``                     |
| [`f55aee66`](https://github.com/NixOS/nixpkgs/commit/f55aee66316a6215d7ae8cda7ae325d6783e2aaf) | `` python312Packages.meteoswiss-async: init at 0.1.1 ``                      |
| [`8c7e7bed`](https://github.com/NixOS/nixpkgs/commit/8c7e7bed25939ce429920ecbfa835a7483680063) | `` vscode-extensions.RoweWilsonFrederiskHolme.wikitext: 3.8.1 -> 3.8.2 ``    |
| [`fa12063f`](https://github.com/NixOS/nixpkgs/commit/fa12063f122652e90bb617ce3c84d4762e342152) | `` ocamlPackages.ocamlbuild: use version 0.14.3 with OCaml 4.07 ``           |
| [`5e6bd6eb`](https://github.com/NixOS/nixpkgs/commit/5e6bd6eb1d3e3075942f3a0973245a821c98b2bb) | `` ocamlPackages.angstrom: 0.16.0 → 0.16.1 ``                                |
| [`77c46bd1`](https://github.com/NixOS/nixpkgs/commit/77c46bd124aae84880fcd5a56e0cc9b86547cc95) | `` python312Packages.unstructured: 0.15.10 -> 0.15.13 ``                     |
| [`c58dd962`](https://github.com/NixOS/nixpkgs/commit/c58dd96276b0c99c6b426aaa7820799d5fc4bb13) | `` python312Packages.aioautomower: 2024.9.0 -> 2024.9.1 ``                   |
| [`f53c6bee`](https://github.com/NixOS/nixpkgs/commit/f53c6bee84870ce5c47bf9789a71ff93f8655981) | `` saunafs: 4.5.0 -> 4.5.1 ``                                                |
| [`5f7485a9`](https://github.com/NixOS/nixpkgs/commit/5f7485a989f9f763f1ccdc2f4fa07c9261a4be21) | `` zsh-wd: 0.8.0 -> 0.9.0 ``                                                 |
| [`4ed45e09`](https://github.com/NixOS/nixpkgs/commit/4ed45e0921f8abefaacae58cbb6f9bb0667320be) | `` aliae: remove static_build ``                                             |
| [`8658b1b6`](https://github.com/NixOS/nixpkgs/commit/8658b1b6481baa7eda843cfd6d48d65327d3330d) | `` appimage-run: Add libsecret for bitwarden ``                              |
| [`74104294`](https://github.com/NixOS/nixpkgs/commit/74104294d028556bb3866425a603a0c2a732ad3d) | `` dbeaver-bin: 24.2.0 -> 24.2.1 ``                                          |
| [`3a0cc443`](https://github.com/NixOS/nixpkgs/commit/3a0cc443ac9ff34b3b7a5d2b2ea02dfefa20495a) | `` deepin.dde-network-core: 2.0.32 -> 2.0.34 ``                              |
| [`01a5ae81`](https://github.com/NixOS/nixpkgs/commit/01a5ae814a7415b6250ee31724b303da8ea13c40) | `` deepin.dde-control-center: 6.0.59 -> 6.0.65 ``                            |
| [`3fb1abdf`](https://github.com/NixOS/nixpkgs/commit/3fb1abdf84cf7f4c9ffcfea50151e9807368276d) | `` deepin.deepin-editor: 6.5.0 -> 6.5.2 ``                                   |
| [`a13a8072`](https://github.com/NixOS/nixpkgs/commit/a13a80723e5cc52e0731ae3d625d17b642c404c5) | `` deepin.dde-launchpad; 0.8.4 -> 1.0.2 ``                                   |
| [`88635b9e`](https://github.com/NixOS/nixpkgs/commit/88635b9e19bced2e2d0a678b7808fb04bce84fea) | `` kubernetes-helmPlugins.helm-diff: 3.9.10 -> 3.9.11 ``                     |
| [`4032dfb9`](https://github.com/NixOS/nixpkgs/commit/4032dfb9355e639165fce999dd878ed379e0074c) | `` tagparser: 12.3.0 -> 12.3.1 ``                                            |
| [`491e455c`](https://github.com/NixOS/nixpkgs/commit/491e455c5173ed2ffface5e2d8a1c6398e5a13d1) | `` shadowsocks-rust: 1.20.4 -> 1.21.0 ``                                     |
| [`e69b0ef6`](https://github.com/NixOS/nixpkgs/commit/e69b0ef60eacae43e8d8963561057798a0b44d2e) | `` qrtool: 0.11.4 -> 0.11.5 ``                                               |
| [`4820dbad`](https://github.com/NixOS/nixpkgs/commit/4820dbad9c089c8c7a14b4346ca3df1c3d762f6a) | `` revive: 1.3.9 -> 1.4.0 ``                                                 |
| [`afeb3ec1`](https://github.com/NixOS/nixpkgs/commit/afeb3ec1dba10c9cf3c63d80c09bb1199804e778) | `` rabtap: 1.42 -> 1.43 ``                                                   |
| [`bacc816c`](https://github.com/NixOS/nixpkgs/commit/bacc816cb0100c304b285b43d6cab0bd62a6bd6d) | `` mailmap: remap cafkafk ``                                                 |
| [`ef9fc985`](https://github.com/NixOS/nixpkgs/commit/ef9fc9852789b388ff79b161fd180539c923c639) | `` ananicy-rules-cachyos: 0-unstable-2024-08-26 -> 0-unstable-2024-09-18 ``  |
| [`162631be`](https://github.com/NixOS/nixpkgs/commit/162631be2b7a5cd8a2d1d54cc1f0e51d49074ab5) | `` uiua: 0.12.3 -> 0.13.0-dev.1 ``                                           |
| [`b050d149`](https://github.com/NixOS/nixpkgs/commit/b050d14946c0de493562f9bde8dc19995591e89e) | `` noson: 5.6.7 -> 5.6.8 ``                                                  |
| [`2fcf8787`](https://github.com/NixOS/nixpkgs/commit/2fcf878726c627ec8d487c0cf5f432167156648d) | `` libraqm: 0.10.1 -> 0.10.2 ``                                              |
| [`7d7b6622`](https://github.com/NixOS/nixpkgs/commit/7d7b6622fd63418bf4791a9815c29192fb60bedc) | `` gitlab-ci-ls: 0.21.1 -> 0.21.2 ``                                         |
| [`124c7e94`](https://github.com/NixOS/nixpkgs/commit/124c7e945bf378487b9bc08751b65b5f113d9a18) | `` xpipe: 11.2 -> 11.3 ``                                                    |
| [`d8eefe56`](https://github.com/NixOS/nixpkgs/commit/d8eefe56554757212964be878e5568d6d33aca1b) | `` autologin: init at 1.0.0 ``                                               |
| [`64063ac4`](https://github.com/NixOS/nixpkgs/commit/64063ac42f7251f286c65364d68504adf5b5bd1f) | `` maintainers: add beviu ``                                                 |
| [`17a50105`](https://github.com/NixOS/nixpkgs/commit/17a50105fb0541ae9bfa77efa2557a3b6977aab8) | `` compose2nix: 0.2.2 -> 0.2.3 ``                                            |
| [`c2393231`](https://github.com/NixOS/nixpkgs/commit/c2393231eb9d0d8aadc6dc5a18147f396526b39b) | `` cargo-temp: 0.2.21 -> 0.2.22 ``                                           |
| [`f80a5b1d`](https://github.com/NixOS/nixpkgs/commit/f80a5b1d94fa1874acbf5b94acd73f7128151252) | `` git-town: 16.1.1 -> 16.2.1 ``                                             |
| [`dfb203e2`](https://github.com/NixOS/nixpkgs/commit/dfb203e2cd5c06bf50fbf310de62649c81cdc9e1) | `` balena-cli: 19.0.3 -> 19.0.12 ``                                          |
| [`d4c147cb`](https://github.com/NixOS/nixpkgs/commit/d4c147cb9747c5b1801f2bd3a6b30f6855d1197e) | `` yandex-music: 5.15.0 -> 5.18.2 ``                                         |
| [`17ddf8b3`](https://github.com/NixOS/nixpkgs/commit/17ddf8b3fc50386a26bab5e1ff33c55c605a46af) | `` arkade: 0.11.24 -> 0.11.26 ``                                             |
| [`6ae535b3`](https://github.com/NixOS/nixpkgs/commit/6ae535b3a6972d7b37a7878dd9adb98125fcd51e) | `` astartectl: 24.5.0 -> 24.5.2 ``                                           |
| [`0fc790f4`](https://github.com/NixOS/nixpkgs/commit/0fc790f4ccd227e67ad2b8df9ecd53e54ce48957) | `` neovim.tests: minor improvements ``                                       |
| [`50b9f412`](https://github.com/NixOS/nixpkgs/commit/50b9f412af62e081ed95150b9831f1d65bfcbaf7) | `` hydrus: use the native test runner ``                                     |
| [`100eefb9`](https://github.com/NixOS/nixpkgs/commit/100eefb99c640ea73432fc5bbc816e379d269182) | `` dopamine: 3.0.0-preview.33 -> 3.0.0-preview.34 ``                         |