### PR TITLE
chore(flake/nixpkgs-stable): `babc25a5` -> `759537f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727129439,
-        "narHash": "sha256-nPyrcFm6FSk7CxzVW4x2hu62aLDghNcv9dX6DF3dXw8=",
+        "lastModified": 1727264057,
+        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "babc25a577c3310cce57c72d5bed70f4c3c3843a",
+        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`759537f0`](https://github.com/NixOS/nixpkgs/commit/759537f06e6999e141588ff1c9be7f3a5c060106) | `` coqPackages.hierarchy-builder: do not pass VFILES if version >= 1.1.0 (#341171) ``                |
| [`aac6c070`](https://github.com/NixOS/nixpkgs/commit/aac6c070f5f0dc87829c88179d7583532787b18d) | `` devenv: 1.1 -> 1.2 ``                                                                             |
| [`4fa7aade`](https://github.com/NixOS/nixpkgs/commit/4fa7aadebd47967516c0489364f32900a536478a) | `` fetchurl: enable TLS verification when credentials are used ``                                    |
| [`3d3fe6e6`](https://github.com/NixOS/nixpkgs/commit/3d3fe6e656e92b74da7cf74f80f8845a7032f622) | `` [Backport release-24.05] rustdesk-flutter: add missing libayatana-appindicator patch (#343894) `` |
| [`a280bb18`](https://github.com/NixOS/nixpkgs/commit/a280bb1899be8353bf5a92054471b51a6c05d13b) | `` koboldcpp: 1.74 -> 1.75.2 ``                                                                      |
| [`4efa2759`](https://github.com/NixOS/nixpkgs/commit/4efa2759e539733681d96051a5997a9c159a4725) | `` brave: 1.69.168 -> 1.70.117 ``                                                                    |
| [`2b45d813`](https://github.com/NixOS/nixpkgs/commit/2b45d813e872169c2cb48d73266e760c4af9065d) | `` microsoft-edge: 128.0.2739.67 -> 129.0.2792.52 ``                                                 |
| [`dcedcd8d`](https://github.com/NixOS/nixpkgs/commit/dcedcd8d584d8db38ac7c1054acf747eecb6ac5c) | `` vivaldi: 6.9.3447.41 -> 6.9.3447.46 ``                                                            |
| [`b1d27e13`](https://github.com/NixOS/nixpkgs/commit/b1d27e13229408717e5c1d1511a7f0194d923bdf) | `` amazon-init: include the general system's software and wrappers in PATH ``                        |
| [`e6fb8a42`](https://github.com/NixOS/nixpkgs/commit/e6fb8a4224ecf6e44c96bc8e6a3b010cb7de2536) | `` amazon-ssm-agent: add the system's software to the path ``                                        |
| [`773aa2b0`](https://github.com/NixOS/nixpkgs/commit/773aa2b0385d83decbd4c472bcb7d7ab16785ac3) | `` villain: 2.1.0 -> 2.2.0 ``                                                                        |
| [`645052a4`](https://github.com/NixOS/nixpkgs/commit/645052a47311e0e5b2a5daa608ca5237ec162055) | `` nixos/sssd: fix KCM to use new krb5 settings ``                                                   |