### PR TITLE
chore(flake/home-manager): `c124568e` -> `ffe2d07e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727346017,
-        "narHash": "sha256-z7OCFXXxIseJhEHiCkkUOkYxD9jtLU8Kf5Q9WC0SjJ8=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c124568e1054a62c20fbe036155cc99237633327",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`ffe2d07e`](https://github.com/nix-community/home-manager/commit/ffe2d07e771580a005e675108212597e5b367d2d) | `` direnv: hopefully final nushell fix ``          |
| [`0afc2f0f`](https://github.com/nix-community/home-manager/commit/0afc2f0f19470e45a3941926a330f2db55ac2fbf) | `` river: reduce risk of large rebuilds in test `` |
| [`853e7bd2`](https://github.com/nix-community/home-manager/commit/853e7bd24f875bac2e3a0cf72f993e917d0f8cf5) | `` direnv: even better nushell fix ``              |
| [`57e6b30d`](https://github.com/nix-community/home-manager/commit/57e6b30d181ae6baff0909a61544ecbe1f642936) | `` direnv: work around nushell bug ``              |