### PR TITLE
chore(flake/stylix): `cf8b6e2d` -> `e3eb7fdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1727218376,
-        "narHash": "sha256-vRYd45uOqzXDaSt8M50hLcsBqIWbEMsflfHk/a1nYA8=",
+        "lastModified": 1727362643,
+        "narHash": "sha256-Ceiq/aYjRlRBU677lBaemn8ZU2Jpr08Iso6UlBc9nFc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "cf8b6e2d4e8aca8ef14b839a906ab5eb98b08561",
+        "rev": "e3eb7fdf8d129ff3676dfbc84ee1262322ca6fb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                        |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`e3eb7fdf`](https://github.com/danth/stylix/commit/e3eb7fdf8d129ff3676dfbc84ee1262322ca6fb4) | `` vesktop: replace home.file with xdg.configFile (#575) ``                    |
| [`31902393`](https://github.com/danth/stylix/commit/3190239337e420afe0d1d4d4b927388e2d29be22) | `` regreet: init (#568) ``                                                     |
| [`4b15fdcc`](https://github.com/danth/stylix/commit/4b15fdcc875dac45c37a7bc79d49a3e9a3062ac7) | `` stylix: remove deprecated 'stylix.palette.<BASE>' options at end-of-life `` |
| [`dba4bd2d`](https://github.com/danth/stylix/commit/dba4bd2d89450fac0295581f795ea9757921f695) | `` treewide: declare end-of-life for deprecated options ``                     |