### PR TITLE
chore(flake/spicetify-nix): `2f429398` -> `cc02909b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727343412,
-        "narHash": "sha256-Uoxb8Qr1bQp05SQIcAYCOfzImOJXIbWk4chTfxsd/us=",
+        "lastModified": 1727410670,
+        "narHash": "sha256-DI22QeBUBIHQQi5XCLq9tmy4z1IPiDD8IpnHVfBL0EM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "2f429398aef267d98858ca98d2f2a38a8ee90fb3",
+        "rev": "cc02909bbfaa51dfe5849cf6997cd2fd0492e972",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`cc02909b`](https://github.com/Gerg-L/spicetify-nix/commit/cc02909bbfaa51dfe5849cf6997cd2fd0492e972) | `` CI update 2024-09-27 `` |