### PR TITLE
chore(flake/spicetify-nix): `cc02909b` -> `65a95ae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727410670,
-        "narHash": "sha256-DI22QeBUBIHQQi5XCLq9tmy4z1IPiDD8IpnHVfBL0EM=",
+        "lastModified": 1727496988,
+        "narHash": "sha256-fi7G9bODA4iUN1g9psIE1U3h7xulNLtwAq0ziwLh0oM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "cc02909bbfaa51dfe5849cf6997cd2fd0492e972",
+        "rev": "65a95ae7c145ed836ca7d4a1e6be5154125490cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`65a95ae7`](https://github.com/Gerg-L/spicetify-nix/commit/65a95ae7c145ed836ca7d4a1e6be5154125490cf) | `` CI update 2024-09-28 `` |