### PR TITLE
chore(flake/stylix): `1e9ec16a` -> `0eea8bcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1727545964,
-        "narHash": "sha256-x9871msLvyZbMNWmVgJWPC2yiSdwZ1K5+UZrQgrdMFM=",
+        "lastModified": 1727635018,
+        "narHash": "sha256-WSc/MF4dUeB2UPMznXYv4LeKK/ulD4xsufdN/L5PoL4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1e9ec16a3739f275ec771434c2ad8cff9a54c42e",
+        "rev": "0eea8bcb0f9c3c7638e7ee64f98ed9b4ec716830",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                      |
| --------------------------------------------------------------------------------------------- | ---------------------------- |
| [`0eea8bcb`](https://github.com/danth/stylix/commit/0eea8bcb0f9c3c7638e7ee64f98ed9b4ec716830) | `` spicetify: init (#574) `` |